### PR TITLE
Git server role

### DIFF
--- a/roles/git-server/README.md
+++ b/roles/git-server/README.md
@@ -1,0 +1,45 @@
+Git Server
+====================
+
+Deploys a HTTPD backed Git server
+
+Requirements
+------------
+
+This role should not be targeted for systems that are part of an OpenShift Cluster as it requires *firewalld* to be installed
+
+Role Variables
+--------------
+
+From this role:
+
+| Name                     | Default value |  Description                                 |
+|--------------------------|---------------|-------------------------------------------------------------------------------------|
+| `git_repo_home`       |  '/opt/git'            | Root location for Git repositories |
+| `git_user` | `git`   | User owning git contents    |
+| `git_user_authorized_keys` | `[]`   | List of public keys to be configured as authorized keys for push access to git repositories    |
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+```
+- name: Creates Git Server
+  hosts: git-server
+  roles:
+  - role: git-server
+```
+
+Compatibility
+------------------
+
+This role was tested and verified with Ansible version `2.1.0.0`
+
+Author Information
+------------------
+
+Andrew Block (ablock@redhat.com)

--- a/roles/git-server/defaults/main.yaml
+++ b/roles/git-server/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+git_repo_home: "/opt/git"
+git_user: "git"
+
+# List of Authorized Keys to Add
+git_user_authorized_keys:

--- a/roles/git-server/handlers/main.yaml
+++ b/roles/git-server/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+
+- name: restart httpd
+  service: 
+    name: httpd
+    state: restarted

--- a/roles/git-server/tasks/main.yaml
+++ b/roles/git-server/tasks/main.yaml
@@ -1,0 +1,45 @@
+---
+- name: Install Packages
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - git
+    - httpd
+    - firewalld
+    - libsemanage-python
+    
+- name: Create Git User
+  user: name="{{ git_user }}"
+
+- name: Create Git User Authorized Keys
+  authorized_key:
+    user: "{{ git_user}}"
+    key: "{{ item }}"
+  with_items:
+    - "{{ git_user_authorized_keys | default('') }}"
+  
+- name: Configure Git HTTP Configuration
+  template:
+    src: "{{ role_path }}/templates/git.conf.j2"
+    dest: "/etc/httpd/conf.d/git.conf"
+    owner: root
+    group: root
+  notify: restart httpd
+
+- name: Enable Services
+  service: name={{ item }} enabled=yes state=started   
+  with_items:
+    - firewalld
+    - httpd 
+    
+- name: HTTPD SELinux Configurations
+  seboolean: 
+    name: httpd_can_network_connect
+    state: yes
+    persistent: yes
+
+- name: Open Firewall for HTTPD
+  firewalld: port=80/tcp permanent=yes state=enabled immediate=yes zone=public
+  
+
+
+ 

--- a/roles/git-server/templates/git.conf.j2
+++ b/roles/git-server/templates/git.conf.j2
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+
+  SetEnv GIT_PROJECT_ROOT {{git_repo_home}}
+  SetEnv GIT_HTTP_EXPORT_ALL
+  SetEnv REMOTE_USER=$REDIRECT_REMOTE_USER
+  AliasMatch ^/git/(.*/objects/[0-9a-f]{2}/[0-9a-f]{38})$          {{git_repo_home}}/$1
+  AliasMatch ^/git/(.*/objects/pack/pack-[0-9a-f]{40}.(pack|idx))$ {{git_repo_home}}/$1
+  ScriptAliasMatch \
+       "(?x)^/git/(.*/(HEAD | \
+		       info/refs | \
+		       objects/info/[^/]+ | \
+		       git-(upload|receive)-pack))$" \
+       /usr/libexec/git-core/git-http-backend/$1
+
+  <Location /git/>
+    Options +ExecCGI +FollowSymLinks
+    Require all granted
+  </Location>
+
+
+  <Directory />
+    Options FollowSymLinks
+    AllowOverride None
+  </Directory>
+
+</VirtualHost>


### PR DESCRIPTION
#### What does this PR do?
Adds a role to create a httpd backed git server

#### How should this be manually tested?

Create a git host group containing target machines and a playbook with the following contents

```
- name: Creates Git Server
  hosts: git
  roles:
  - role: git-server
```

#### Is there a relevant Issue open for this?
None

#### Who would you like to review this?
/cc @detiber @etsauer @oybed 
