### PR TITLE
Role for seeding a git server with OpenShift example repositories

### DIFF
--- a/roles/seed-git-server/README.md
+++ b/roles/seed-git-server/README.md
@@ -1,0 +1,46 @@
+Seed Git Server
+====================
+
+Seeds a git server with example repositories 
+
+Requirements
+------------
+
+This role has dependencies that are not suitable for systems that are part of an OpenShift Cluster as it requires *firewalld* to be installed
+
+
+Role Variables
+--------------
+
+From this role:
+
+| Name                     | Default value |  Description                                 |
+|--------------------------|---------------|-------------------------------------------------------------------------------------|
+| `openshift_git_repo_home`       |  `{{ git_repo_home }}/openshift`           | Base directory for example repositories |
+| `openshift_example_repos` | `[https://github.com/openshift/cakephp-ex.git,https://github.com/openshift/dancer-ex.git,https://github.com/jboss-openshift/openshift-quickstarts.git,https://github.com/openshift/django-ex.git,https://github.com/openshift/nodejs-ex.git,https://github.com/openshift/rails-ex.git]`   | Example repositories to seed into repository    |
+
+Dependencies
+------------
+
+* git-server
+
+
+Example Playbook
+----------------
+
+```
+- name: Seed git server
+  hosts: git-server
+  roles:
+  - role: seed-git-server
+```
+
+Compatibility
+------------------
+
+This role was tested and verified with Ansible version `2.1.0.0`
+
+Author Information
+------------------
+
+Andrew Block (ablock@redhat.com)

--- a/roles/seed-git-server/defaults/main.yaml
+++ b/roles/seed-git-server/defaults/main.yaml
@@ -1,0 +1,11 @@
+---
+
+openshift_git_repo_home: "{{ git_repo_home }}/openshift"
+openshift_example_repos:
+ - "https://github.com/openshift/cakephp-ex.git"
+ - "https://github.com/openshift/dancer-ex.git"
+ - "https://github.com/jboss-openshift/openshift-quickstarts.git"
+ - "https://github.com/openshift/django-ex.git"
+ - "https://github.com/openshift/nodejs-ex.git"
+ - "https://github.com/openshift/rails-ex.git"
+

--- a/roles/seed-git-server/meta/main.yml
+++ b/roles/seed-git-server/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- role: git-server

--- a/roles/seed-git-server/tasks/main.yaml
+++ b/roles/seed-git-server/tasks/main.yaml
@@ -1,0 +1,23 @@
+---
+
+- name: Create OpenShift Git Repository Content Home
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ git_user }}"
+    group: "{{ git_user }}"
+  with_items:
+    - "{{ git_repo_home }}"
+    - "{{ openshift_git_repo_home }}"
+
+- name: Clone OpenShift Examples
+  git:
+    repo: "{{ item }}"
+    bare: yes
+    dest: "{{ openshift_git_repo_home }}/{{ item | basename }}"
+  with_items:
+    - "{{ openshift_example_repos }}"
+  become: yes
+  become_user: "{{ git_user }}"
+
+  


### PR DESCRIPTION
#### What does this PR do?
Role for seeding git server introduced by #9 with example repositories

#### How should this be manually tested?

Create a git host group containing target machines and a playbook with the following contents

```
- name: Creates Git Server
  hosts: git
  roles:
  - role: seed-git-server
```

#### Is there a relevant Issue open for this?
None

#### Who would you like to review this?
/cc @detiber @etsauer @oybed 

