### PR TITLE
fix up of add-node warning

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/roles/instance-groups/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/instance-groups/tasks/main.yaml
@@ -43,5 +43,5 @@
     groups: new_nodes
     openshift_node_labels:
       role: "{{ node_type }}" 
-  with_items: "{{ groups['tag_provision_node'] }}"
+  with_items: "{{ groups.tag_provision_node | default([]) }}"
   when: add_node is defined


### PR DESCRIPTION
Resolves #57 

```
PLAY [localhost] ***************************************************************

TASK [instance-groups : Add bastion to group] **********************************
changed: [localhost]

TASK [instance-groups : Add masters to requisite groups] ***********************
changed: [localhost] => (item=ip-10-20-4-209.ec2.internal)
changed: [localhost] => (item=ip-10-20-5-254.ec2.internal)
changed: [localhost] => (item=ip-10-20-6-145.ec2.internal)

TASK [instance-groups : Add a master to the primary masters group] *************
changed: [localhost] => (item=ip-10-20-4-209.ec2.internal)

TASK [instance-groups : Add infra instances to host group] *********************
changed: [localhost] => (item=ip-10-20-4-44.ec2.internal)
changed: [localhost] => (item=ip-10-20-5-138.ec2.internal)

TASK [instance-groups : Add app instances to host group] ***********************
changed: [localhost] => (item=ip-10-20-4-91.ec2.internal)
changed: [localhost] => (item=ip-10-20-5-238.ec2.internal)

TASK [instance-groups : Add app instances to host group] ***********************

PLAY [localhost] ***************************************************************

TASK [host-up : check to see if host is available] *****************************
ok: [localhost]

PLAY [cluster_hosts] ***********************************************************
```
