### PR TITLE
Exit with nonzero when ansible-playbook fails.

### DIFF
--- a/reference-architecture/aws-ansible/ose-on-aws.py
+++ b/reference-architecture/aws-ansible/ose-on-aws.py
@@ -258,7 +258,8 @@ def launch_refarch_env(region=None,
 
     status = os.system(command)
     if os.WIFEXITED(status) and os.WEXITSTATUS(status) != 0:
-      return os.WEXITSTATUS(status)
+      sys.exit(os.WEXITSTATUS(status))
+
 
 if __name__ == '__main__':
   # check for AWS access info


### PR DESCRIPTION
Let's just propagate the exit status of the last executed ansible-playbook command.