### PR TITLE
ssh, variable and ansible fixes

### DIFF
--- a/reference-architecture/gce-ansible/playbooks/openshift-setup.yaml
+++ b/reference-architecture/gce-ansible/playbooks/openshift-setup.yaml
@@ -36,6 +36,7 @@
     osm_default_subdomain: "{{ wildcard_zone }}"
     osm_default_node_selector: "role=app"
     openshift_deployment_type: openshift-enterprise
+    deployment_type: "{{ openshift_deployment_type }}"
     openshift_master_identity_providers:
     - name: google
       kind: GoogleIdentityProvider

--- a/reference-architecture/gce-ansible/playbooks/roles/validate-app/tasks/main.yaml
+++ b/reference-architecture/gce-ansible/playbooks/roles/validate-app/tasks/main.yaml
@@ -7,17 +7,17 @@
   command: "{{ openshift.common.client_binary }} new-project validate"
 
 - name: Create Hello world app
-  shell: "{{ openshift.common.client_binary }} new-app --template cakephp-example"
+  shell: "{{ openshift.common.client_binary }} new-app --template cakephp-mysql-example"
 
 - name: Wait for build to complete
-  shell: "{{ openshift.common.client_binary }} get pod | grep -v deploy | awk '/cakephp-example-1-build/{ print $3 }'"
+  shell: "{{ openshift.common.client_binary }} get pod | grep -v deploy | awk '/cakephp-mysql-example-1-build/{ print $3 }'"
   register: build_output
   until: build_output.stdout | search("Completed")
   retries: 30
   delay: 15
 
 - name: Wait for App to be running
-  shell: "{{ openshift.common.client_binary }} get pod | grep -v deploy | grep -v build  | awk '/cakephp-example-1-*/{print $3}'"
+  shell: "{{ openshift.common.client_binary }} get pod | grep -v deploy | grep -v build  | awk '/cakephp-mysql-example-1-*/{print $3}'"
   register: deployer_output
   until: deployer_output.stdout | search("Running")
   retries: 30
@@ -28,7 +28,7 @@
      seconds: 10
 - name: check the status of the page
   uri:
-     url: "http://cakephp-example-validate.{{ wildcard_zone }}"
+     url: "http://cakephp-mysql-example-validate.{{ wildcard_zone }}"
      status_code: 200
      method: GET
 

--- a/reference-architecture/gce-cli/config.sh.example
+++ b/reference-architecture/gce-cli/config.sh.example
@@ -19,15 +19,16 @@ DNS_DOMAIN='ocp.example.com'
 # Name of the DNS zone in the Google Cloud DNS. If empty, it will be created
 DNS_DOMAIN_NAME='ocp-example-com'
 # DNS name for the Master service
-MASTER_DNS_NAME='master.ocp.example.com'
+MASTER_DNS_NAME="master.${DNS_DOMAIN}"
 # Internal DNS name for the Master service
-INTERNAL_MASTER_DNS_NAME='internal-master.ocp.example.com'
+INTERNAL_MASTER_DNS_NAME="internal.${DNS_DOMAIN}"
 # Domain name for the OpenShift applications
-OCP_APPS_DNS_NAME='apps.ocp.example.com'
+OCP_APPS_DNS_NAME="apps.${DNS_DOMAIN}"
 # Paths on the local system for the certificate files. If empty, self-signed
 # certificate will be generated
-MASTER_HTTPS_CERT_FILE="${HOME}/Downloads/master.ose.example.com.pem"
-MASTER_HTTPS_KEY_FILE="${HOME}/Downloads/master.ose.example.com.key"
+MASTER_HTTPS_CERT_FILE="${HOME}/master.${DNS_DOMAIN}.pem"
+MASTER_HTTPS_KEY_FILE="${HOME}/master.${DNS_DOMAIN}.key"
+
 
 # OpenShift Identity providers. This is Google oauth example (hosted_domain is optional and restricts login to users only from the specified domain)
 OCP_IDENTITY_PROVIDERS='[ {"name": "google", "kind": "GoogleIdentityProvider", "login": "true", "challenge": "false", "mapping_method": "claim", "client_id": "xxx-yyy.apps.googleusercontent.com", "client_secret": "zzz", "hosted_domain": "example.com"} ]'
@@ -82,6 +83,7 @@ ROUTER_NETWORK_LB_POOL='router-network-lb-pool'
 ROUTER_NETWORK_LB_IP='router-network-lb-ip'
 ROUTER_NETWORK_LB_RULE='router-network-lb-rule'
 
+IMAGE_BUCKET="${GCLOUD_PROJECT}-rhel-guest-raw-image"
 REGISTRY_BUCKET="${GCLOUD_PROJECT}-openshift-docker-registry"
 
 TEMP_INSTANCE='ocp-rhel-temp'

--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -312,7 +312,6 @@ if ! gcloud --project "$GCLOUD_PROJECT" compute images describe "$RHEL_IMAGE_GCE
     qemu-img convert -p -S 4096 -f qcow2 -O raw "$RHEL_IMAGE_PATH" disk.raw
     echo 'Creating archive of raw image:'
     tar -Szcvf "${RHEL_IMAGE}.tar.gz" disk.raw
-    #bucket='gs://ocp-rhel-guest-raw-image'
     bucket="gs://${IMAGE_BUCKET}"
     gsutil ls -p "$GCLOUD_PROJECT" "$bucket" &>/dev/null || gsutil mb -p "$GCLOUD_PROJECT" -l "$GCLOUD_REGION" "$bucket"
     gsutil ls -p "$GCLOUD_PROJECT" "${bucket}/${RHEL_IMAGE}.tar.gz" &>/dev/null || gsutil cp "${RHEL_IMAGE}.tar.gz" "$bucket"

--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -312,7 +312,8 @@ if ! gcloud --project "$GCLOUD_PROJECT" compute images describe "$RHEL_IMAGE_GCE
     qemu-img convert -p -S 4096 -f qcow2 -O raw "$RHEL_IMAGE_PATH" disk.raw
     echo 'Creating archive of raw image:'
     tar -Szcvf "${RHEL_IMAGE}.tar.gz" disk.raw
-    bucket='gs://ocp-rhel-guest-raw-image'
+    #bucket='gs://ocp-rhel-guest-raw-image'
+    bucket="gs://${IMAGE_BUCKET}"
     gsutil ls -p "$GCLOUD_PROJECT" "$bucket" &>/dev/null || gsutil mb -p "$GCLOUD_PROJECT" -l "$GCLOUD_REGION" "$bucket"
     gsutil ls -p "$GCLOUD_PROJECT" "${bucket}/${RHEL_IMAGE}.tar.gz" &>/dev/null || gsutil cp "${RHEL_IMAGE}.tar.gz" "$bucket"
     gcloud --project "$GCLOUD_PROJECT" compute images create "$RHEL_IMAGE_GCE" --source-uri "${bucket}/${RHEL_IMAGE}.tar.gz"
@@ -341,6 +342,10 @@ done
 # Create SSH key for GCE
 if [ ! -f ~/.ssh/google_compute_engine ]; then
     ssh-keygen -t rsa -f ~/.ssh/google_compute_engine -C cloud-user -N ''
+    SSH_AGENT_PID=${SSH_AGENT_PID:-}
+    if [ -z $SSH_AGENT_PID ]; then
+        eval $(ssh-agent -s)
+    fi
     ssh-add ~/.ssh/google_compute_engine
 fi
 
@@ -638,6 +643,7 @@ fi
 
 # Configure local SSH so we can connect directly to all instances
 ssh_config_file=~/.ssh/config
+touch $ssh_config_file
 sed -i '/^# OpenShift on GCE Section$/,/^# End of OpenShift on GCE Section$/d' "$ssh_config_file"
 echo -e '# OpenShift on GCE Section\n' >> "$ssh_config_file"
 bastion_data=$(gcloud --project "$GCLOUD_PROJECT" compute instances list --filter='name:bastion' --format='value(EXTERNAL_IP,id)')


### PR DESCRIPTION
A couple things in this PR.

On a fresh environment, some of the assumptions about the environment re: ssh are not correct. I put in some logic to account for that.

During testing, the openshift-ansible-playbooks rpm was updated, and seemed to break the openshift-install.yaml playbook. A variable was changed/added? And the cakephp template is no longer deployed. I tweaked the ansible playbook a bit to address those changes.

On my tests, the bucket for the RAW image was already present but created by a different user? So I could not delete or use it. I variable'ized it as IMAGE_BUCKET and updated the sample config accordingly.

I also screwed up a couple of installs by not updating my FQDN everywhere, so I flipped the hostnames to dervice the domain from the variable already present, $DNS_DOMAIN.
