### PR TITLE
Ports for metrics and logging 

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
@@ -407,8 +407,8 @@
       "Properties":{
         "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
         "IpProtocol": "tcp",
-        "FromPort": { "Ref": "24224" },
-        "ToPort": { "Ref": "24224" },
+        "FromPort": "24224",
+        "ToPort": "24224",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
@@ -417,8 +417,8 @@
       "Properties":{
         "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
         "IpProtocol": "udp",
-        "FromPort": { "Ref": "24224" },
-        "ToPort": { "Ref": "24224" },
+        "FromPort": "24224",
+        "ToPort": "24224",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
@@ -392,6 +392,26 @@
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
+    "LoggingTCP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "24224" },
+        "ToPort": { "Ref": "24224" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "LoggingUDP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "udp",
+        "FromPort": { "Ref": "24224" },
+        "ToPort": { "Ref": "24224" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
     "MasterIngressMastersAPITCP": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties":{

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
@@ -319,7 +319,7 @@
         "IpProtocol": "tcp",
         "FromPort": "10250",
         "ToPort": "10250",
-        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
     "NodeIngressNodeVXLAN": {

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json
@@ -319,6 +319,16 @@
         "IpProtocol": "tcp",
         "FromPort": "10250",
         "ToPort": "10250",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "NodeIngressNodeKubelet": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "10250",
+        "ToPort": "10250",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
@@ -347,6 +347,16 @@
         "IpProtocol": "tcp",
         "FromPort": "10250",
         "ToPort": "10250",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "NodeIngressNodeKubelet": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "10250",
+        "ToPort": "10250",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
@@ -435,8 +435,8 @@
       "Properties":{
         "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
         "IpProtocol": "tcp",
-        "FromPort": { "Ref": "24224" },
-        "ToPort": { "Ref": "24224" },
+        "FromPort": "24224",
+        "ToPort": "24224",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
@@ -445,8 +445,8 @@
       "Properties":{
         "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
         "IpProtocol": "udp",
-        "FromPort": { "Ref": "24224" },
-        "ToPort": { "Ref": "24224" },
+        "FromPort": "24224",
+        "ToPort": "24224",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
@@ -347,7 +347,7 @@
         "IpProtocol": "tcp",
         "FromPort": "10250",
         "ToPort": "10250",
-        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
     "NodeIngressNodeVXLAN": {

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield.json
@@ -420,6 +420,26 @@
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
+    "LoggingTCP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "24224" },
+        "ToPort": { "Ref": "24224" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "LoggingUDP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "udp",
+        "FromPort": { "Ref": "24224" },
+        "ToPort": { "Ref": "24224" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
     "MasterIngressMastersAPITCP": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties":{

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
@@ -542,7 +542,7 @@
         "IpProtocol": "tcp",
         "FromPort": "10250",
         "ToPort": "10250",
-        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
     "NodeIngressNodeVXLAN": {

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
@@ -542,6 +542,16 @@
         "IpProtocol": "tcp",
         "FromPort": "10250",
         "ToPort": "10250",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] }
+      }
+    },
+    "NodeIngressNodeKubelet": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "10250",
+        "ToPort": "10250",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
@@ -630,8 +630,8 @@
       "Properties":{
         "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
         "IpProtocol": "tcp",
-        "FromPort": { "Ref": "24224" },
-        "ToPort": { "Ref": "24224" },
+        "FromPort": "24224",
+        "ToPort": "24224",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
@@ -640,8 +640,8 @@
       "Properties":{
         "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
         "IpProtocol": "udp",
-        "FromPort": { "Ref": "24224" },
-        "ToPort": { "Ref": "24224" },
+        "FromPort": "24224",
+        "ToPort": "24224",
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/greenfield.json
@@ -615,6 +615,26 @@
         "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
       }
     },
+    "LoggingTCP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": { "Ref": "24224" },
+        "ToPort": { "Ref": "24224" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
+    "LoggingUDP": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties":{
+        "GroupId": { "Fn::GetAtt": [ "MasterSG", "GroupId" ] },
+        "IpProtocol": "udp",
+        "FromPort": { "Ref": "24224" },
+        "ToPort": { "Ref": "24224" },
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "NodeSG", "GroupId" ] }
+      }
+    },
     "MasterIngressMastersAPITCP": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties":{


### PR DESCRIPTION
Currently not offering metrics in logging in the reference architecture but if a customer were wanting to add the feature it would be good to have the ports open.