### PR TITLE
remove . from sudoers.d filename

### DIFF
--- a/reference-architecture/osp-cli/ch4.5.1_user_data.sh
+++ b/reference-architecture/osp-cli/ch4.5.1_user_data.sh
@@ -17,7 +17,7 @@ function generate_host_info() {
 hostname: $1
 fqdn: $1.$2
 write_files: 
-  - path: /etc/sudoers.d/99-openshift.ssh_user-requiretty
+  - path: /etc/sudoers.d/99-openshift_ssh_user-requiretty
     permissions: 440
     content: |
       Defaults:cloud-user !requiretty


### PR DESCRIPTION
Apparently dots (.) in `sudoers.d` configuration file names prevents them from being read and used.

This patch replaces the dot in the filename with an underscore, allowing the `!requiretty` adjustment to be used when creating new OSP instances.