### PR TITLE
create the user-data directory if needed

### DIFF
--- a/reference-architecture/osp-cli/ch4.5.1_user_data.sh
+++ b/reference-architecture/osp-cli/ch4.5.1_user_data.sh
@@ -53,6 +53,9 @@ function generate_docker_storage_setup() {
 EOF
 }
 
+# Create the user-data directory if needed
+[ -d user-data ] || mkdir user-data
+
 for HOST in $ALL_HOSTS ; do
   generate_host_info ${HOST} ${DOMAIN} > user-data/${HOST}.yaml
 done


### PR DESCRIPTION
This patch creates the `user-data` directory if it does not exist.  If the directory is not created, following attempts to write user data files for new instances will also fail and the boot commands will then fail.

This patch removes the requirement that the caller pre-create the `user-data` direcory.