### PR TITLE
added function to find net id by name for use on rhel7.x

### DIFF
--- a/reference-architecture/osp-cli/ch4.5.2_boot_bastion.sh
+++ b/reference-architecture/osp-cli/ch4.5.2_boot_bastion.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 DOMAIN=${DOMAIN:-ocp3.example.com}
 GLANCE_IMAGE=${GLANCE_IMAGE:-rhel72}
+
+# Retrive a Neutron net id by name
+function net_id_by_name() {
+    # NAME=$1
+    neutron net-list --field id --field name | grep $1 | cut -d' ' -f2
+}
+
 nova boot --flavor m1.small --image ${GLANCE_IMAGE} --key-name ocp3 \
-  --nic net-name=control-network --nic net-name=tenant-network \
+  --nic net-id=$(net_id_by_name control-network) \
+  --nic net-id=$(net_id_by_name tenant-network) \
   --security-groups bastion-sg \
   --user-data=user-data/bastion.yaml \
   bastion.${DOMAIN}

--- a/reference-architecture/osp-cli/ch4.5.3_boot_masters.sh
+++ b/reference-architecture/osp-cli/ch4.5.3_boot_masters.sh
@@ -2,9 +2,16 @@
 DOMAIN=${DOMAIN:-ocp3.example.com}
 GLANCE_IMAGE=${GLANCE_IMAGE:-rhel72}
 
+# Retrive a Neutron net id by name
+function net_id_by_name() {
+    # NAME=$1
+    neutron net-list --field id --field name | grep $1 | cut -d' ' -f2
+}
+
 for HOSTNUM in 0 1 2 ; do
   nova boot --flavor m1.small --image ${GLANCE_IMAGE} --key-name ocp3 \
-   --nic net-name=control-network --nic net-name=tenant-network \
+  --nic net-id=$(net_id_by_name control-network) \
+  --nic net-id=$(net_id_by_name tenant-network) \
    --security-groups master-sg \
    --user-data=user-data/master-${HOSTNUM}.yaml \
   master-${HOSTNUM}.${DOMAIN}

--- a/reference-architecture/osp-cli/ch4.5.4_cinder_volumes.sh
+++ b/reference-architecture/osp-cli/ch4.5.4_cinder_volumes.sh
@@ -1,11 +1,8 @@
 #!/bin/sh
 VOLUME_SIZE=${VOLUME_SIZE:-8}
-BASTION="bastion"
-MASTERS="master-0 master-1 master-2"
 INFRA_NODES="infra-node-0 infra-node-1"
 APP_NODES="app-node-0 app-node-1 app-node-2"
 ALL_NODES="$INFRA_NODES $APP_NODES"
-ALL_HOSTS="$BASTION $MASTERS $ALL_NODES"
 
 for NODE in $ALL_NODES ; do
     cinder create --name ${NODE}-docker ${VOLUME_SIZE}

--- a/reference-architecture/osp-cli/ch4.5.5_boot_app_nodes.sh
+++ b/reference-architecture/osp-cli/ch4.5.5_boot_app_nodes.sh
@@ -1,12 +1,20 @@
 #!/bin/sh
 DOMAIN=${DOMAIN:-ocp3.example.com}
 GLANCE_IMAGE=${GLANCE_IMAGE:-rhel72}
+
+# Retrive a Neutron net id by name
+function net_id_by_name() {
+    # NAME=$1
+    neutron net-list --field id --field name | grep $1 | cut -d' ' -f2
+}
+
 for HOSTNAME in app-node-0 app-node-1 app-node-2
 do
   VOLUMEID=$(cinder show ${HOSTNAME}-docker | grep ' id ' | awk '{print $4}')
   
   nova boot --flavor m1.medium --image ${GLANCE_IMAGE} --key-name ocp3 \
-   --nic net-name=control-network --nic net-name=tenant-network \
+  --nic net-id=$(net_id_by_name control-network) \
+  --nic net-id=$(net_id_by_name tenant-network) \
    --security-groups node-sg \
    --block-device source=volume,dest=volume,device=vdb,id=${VOLUMEID} \
    --user-data=user-data/${HOSTNAME}.yaml \

--- a/reference-architecture/osp-cli/ch4.5.5_boot_infra_nodes.sh
+++ b/reference-architecture/osp-cli/ch4.5.5_boot_infra_nodes.sh
@@ -1,12 +1,20 @@
 #!/bin/sh
 DOMAIN=${DOMAIN:-ocp3.example.com}
 GLANCE_IMAGE=${GLANCE_IMAGE:-rhel72}
+
+# Retrive a Neutron net id by name
+function net_id_by_name() {
+    # NAME=$1
+    neutron net-list --field id --field name | grep $1 | cut -d' ' -f2
+}
+
 for HOSTNAME in infra-node-0 infra-node-1
 do
   VOLUMEID=$(cinder show ${HOSTNAME}-docker | grep ' id ' | awk '{print $4}')
 
   nova boot --flavor m1.medium --image ${GLANCE_IMAGE} --key-name ocp3 \
-   --nic net-name=control-network --nic net-name=tenant-network \
+   --nic net-id=$(net_id_by_name control-network) \
+   --nic net-id=$(net_id_by_name tenant-network) \
    --security-groups infra-sg \
    --block-device source=volume,dest=volume,device=vdb,id=${VOLUMEID} \
    --user-data=user-data/${HOSTNAME}.yaml \


### PR DESCRIPTION
This change causes the instance boot scripts to use the `--nic net-id=` form for identifying networks when booting new instances.  The `--nic net-name` form is not yet available on RHEL7.x for the nova CLI client.

This change adds a function `net_id_by_name` to each script that runs a `nova boot` and then uses that to look up the network id.

This change allows the refarch manual CLI scripts to execute properly on RHEL7x hosts.