### PR TITLE
Disable update of WALinuxAgent

### DIFF
--- a/reference-architecture/azure-ansible/store.sh
+++ b/reference-architecture/azure-ansible/store.sh
@@ -32,7 +32,7 @@ chmod 600 /root/.ssh/id_rsa.pub
 chown root /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 
-yum -y update
+yum -y update --exclude=WALinuxAgent*
 yum -y install targetcli
 yum -y install lvm2
 systemctl start target


### PR DESCRIPTION
Current version of WALinuxAgent aborts the update. Disable the update of agent until problem resolved. This is blocking storage service to come up.