### PR TITLE
Brownfield is not calling the template correctly

### DIFF
--- a/reference-architecture/aws-ansible/ose-on-aws.py
+++ b/reference-architecture/aws-ansible/ose-on-aws.py
@@ -245,6 +245,7 @@ def launch_refarch_env(region=None,
     ami=%s \
     keypair=%s \
     create_key=%s \
+    add_node=no \
     key_path=%s \
     create_vpc=%s \
     vpc_id=%s \

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/main.yaml
@@ -52,7 +52,7 @@
 
 - name: Create Brownfield Infrastructure
   cloudformation:
-    stack_name: "{{ stack_name }}-brownfield"
+    stack_name: "{{ stack_name }}"
     state: "present"
     region: "{{ region }}"
     template: "roles/cloudformation-infra/files/brownfield.json"
@@ -105,7 +105,7 @@
 
 - name: Create Brownfield Infrastructure with existing bastion
   cloudformation:
-    stack_name: "{{ stack_name }}-brownfield-wo-bastion"
+    stack_name: "{{ stack_name }}"
     state: "present"
     region: "{{ region }}"
     template: "roles/cloudformation-infra/files/brownfield-byo-bastion.json"


### PR DESCRIPTION
This fixes an a missing variable issue when it comes to a brownfield deployment and allows for the correct stack to be called when asking for cloudformation outputs.