### PR TITLE
Fix Vagrant roles symlink

### DIFF
--- a/vagrant/roles/rhsm-repos
+++ b/vagrant/roles/rhsm-repos
@@ -1,1 +1,1 @@
-../../reference-architecture/aws-ansible/playbooks/roles/rhsm-repos
+../../roles/rhsm-repos/

--- a/vagrant/roles/rhsm-subscription
+++ b/vagrant/roles/rhsm-subscription
@@ -1,1 +1,1 @@
-../../reference-architecture/aws-ansible/playbooks/roles/rhsm-subscription
+../../roles/rhsm-subscription/


### PR DESCRIPTION
Looks like a couple of role symlinks are broken for vagrant