### PR TITLE
refactor restart atomic-openshift-node task to work with origin

### DIFF
--- a/roles/openshift-emptydir-quota/handlers/main.yaml
+++ b/roles/openshift-emptydir-quota/handlers/main.yaml
@@ -1,5 +1,5 @@
 ---
-    - name: restart atomic-openshift-node
+    - name: restart openshift-node
       service:
-        name: atomic-openshift-node
+        name: "{{ openshift.common.service_type }}-node"
         state: restarted

--- a/roles/openshift-emptydir-quota/tasks/main.yaml
+++ b/roles/openshift-emptydir-quota/tasks/main.yaml
@@ -6,4 +6,4 @@
       replace:  '\1 perFSGroup: 512Mi\2'
       backup: yes
   notify:
-  - restart atomic-openshift-node
+  - restart openshift-node


### PR DESCRIPTION
Instead of calling service atomic-openshift-node restart use the correct service and for other deployment types (like origin)