### PR TITLE
Define openshift_master_default_subdomain

### DIFF
--- a/reference-architecture/gce-ansible/playbooks/openshift-setup.yaml
+++ b/reference-architecture/gce-ansible/playbooks/openshift-setup.yaml
@@ -35,6 +35,7 @@
     openshift_master_cluster_hostname: "internal-openshift-master.{{ public_hosted_zone }}"
     openshift_master_cluster_public_hostname: "openshift-master.{{ public_hosted_zone }}"
     osm_default_subdomain: "{{ wildcard_zone }}"
+    openshift_master_default_subdomain: "{{osm_default_subdomain}}"
     osm_default_node_selector: "role=app"
     openshift_deployment_type: openshift-enterprise
     deployment_type: "{{ openshift_deployment_type }}"


### PR DESCRIPTION
This ansible definition is required to get the router default subdomain to work.  This is required for the app validation playbook to work properly.