### PR TITLE
Registry should only one pod due to nfs

### DIFF
--- a/reference-architecture/vmware-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/vmware-ansible/playbooks/openshift-install.yaml
@@ -26,7 +26,7 @@
     openshift_master_debug_level: "{{ master_debug_level | default(debug_level, true) }}"
     openshift_master_access_token_max_seconds: 2419200
     openshift_hosted_router_replicas: 2
-    openshift_hosted_registry_replicas: 2
+    openshift_hosted_registry_replicas: 1
     openshift_master_api_port: "{{ console_port }}"
     openshift_master_console_port: "{{ console_port }}"
     openshift_master_logging_public_url: "https://kibana.{{ osm_default_subdomain }}"

--- a/reference-architecture/vmware-ansible/playbooks/roles/openshift-registry/tasks/main.yaml
+++ b/reference-architecture/vmware-ansible/playbooks/roles/openshift-registry/tasks/main.yaml
@@ -16,7 +16,7 @@
   ignore_errors: true
 
 - name: Install registry
-  command: "oadm registry --selector='role=infra' --replicas=2 --config=/etc/origin/master/admin.kubeconfig --service-account=registry"
+  command: "oadm registry --selector='role=infra' --replicas=1 --config=/etc/origin/master/admin.kubeconfig --service-account=registry"
   when: registry_out | failed
   ignore_errors: true
 


### PR DESCRIPTION
When using NFS for the OpenShift registry it is advised to not use NFS among multiple nodes.  