### PR TITLE
no longer forcing a primary master

### DIFF
--- a/playbooks/post-validation.yaml
+++ b/playbooks/post-validation.yaml
@@ -15,7 +15,7 @@
   roles:
   - validate-etcd
 
-- hosts: primary_master
+- hosts: single_master
   gather_facts: yes
   become: yes
   roles:

--- a/reference-architecture/aws-ansible/playbooks/add-node.yaml
+++ b/reference-architecture/aws-ansible/playbooks/add-node.yaml
@@ -13,7 +13,7 @@
 
 - include: node-setup.yaml
 
-- hosts: primary_master
+- hosts: single_master
   gather_facts: yes
   become: yes
   vars_files:

--- a/reference-architecture/aws-ansible/playbooks/roles/instance-groups/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/instance-groups/tasks/main.yaml
@@ -17,10 +17,10 @@
   when:
     - hostvars[item]['ec2_tag_aws_cloudformation_stack_name'] == "{{ stack_name }}"
 
-- name: Add a master to the primary masters group
+- name: Add a master to the single master group
   add_host:
     name: "{{ item }}"
-    groups: primary_master
+    groups: single_master
     openshift_node_labels:
       role: master
       KubernetesCluster: "{{ stack_name }}"

--- a/reference-architecture/gce-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/gce-ansible/playbooks/openshift-install.yaml
@@ -41,7 +41,7 @@
 - include: ../../../playbooks/empty-dir-quota.yaml
 
 
-- hosts: primary_master
+- hosts: single_master
   gather_facts: no
   roles:
     - openshift-registry

--- a/reference-architecture/gce-ansible/playbooks/roles/instance-groups/tasks/main.yaml
+++ b/reference-architecture/gce-ansible/playbooks/roles/instance-groups/tasks/main.yaml
@@ -7,10 +7,10 @@
       role: master
   with_items: "{{ groups['tag_ocp-master'] }}"
 
-- name: Add a master to the primary masters group
+- name: Add a master to the single masters group
   add_host:
     name: "{{ hostvars[item].gce_name }}"
-    groups: primary_master
+    groups: single_master
     openshift_node_labels:
       role: master
   with_items: "{{ groups['tag_ocp-master'].0 }}"

--- a/reference-architecture/gce-ansible/playbooks/validation.yaml
+++ b/reference-architecture/gce-ansible/playbooks/validation.yaml
@@ -19,7 +19,7 @@
   roles:
     - validate-etcd
 
-- hosts: primary_master
+- hosts: single_master
   gather_facts: no
   roles:
     - validate-app

--- a/reference-architecture/vmware-ansible/playbooks/openshift-configure.yaml
+++ b/reference-architecture/vmware-ansible/playbooks/openshift-configure.yaml
@@ -9,7 +9,7 @@
 
 - include: ../../../playbooks/empty-dir-quota.yaml
 
-- hosts: primary_master
+- hosts: single_master
   gather_facts: yes
   become: yes
   vars_files:

--- a/reference-architecture/vmware-ansible/playbooks/roles/instance-groups/tasks/main.yaml
+++ b/reference-architecture/vmware-ansible/playbooks/roles/instance-groups/tasks/main.yaml
@@ -7,10 +7,10 @@
       role: master
   with_items: "{{ groups['master'] }}"
 
-- name: Add a master to the primary masters group
+- name: Add a master to the single master group
   add_host:
     name: "{{ hostvars[item].inventory_hostname }}"
-    groups: primary_master
+    groups: single_master
     openshift_node_labels:
       role: master
   with_items: "{{ groups['master'][0] }}"


### PR DESCRIPTION
We will let the installer decide the primary master rather than forcing one to be assigned. This should resolve issue #257 