### PR TITLE
git is required when running containerized

### DIFF
--- a/playbooks/prerequisite.yaml
+++ b/playbooks/prerequisite.yaml
@@ -14,7 +14,7 @@
   - prerequisites
 
 - hosts: master
-  gather_facts: no
+  gather_facts: yes
   become: yes
   roles:
   - master-prerequisites

--- a/playbooks/prerequisite.yaml
+++ b/playbooks/prerequisite.yaml
@@ -12,3 +12,9 @@
   roles:
   - rhsm-repos
   - prerequisites
+
+- hosts: masters 
+  gather_facts: no
+  become: yes
+  roles:
+  - master-prerequisites

--- a/playbooks/prerequisite.yaml
+++ b/playbooks/prerequisite.yaml
@@ -13,7 +13,7 @@
   - rhsm-repos
   - prerequisites
 
-- hosts: masters 
+- hosts: master
   gather_facts: no
   become: yes
   roles:

--- a/roles/master-prerequisites/library/openshift_facts.py
+++ b/roles/master-prerequisites/library/openshift_facts.py
@@ -1,1 +1,0 @@
-/usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py

--- a/roles/master-prerequisites/library/openshift_facts.py
+++ b/roles/master-prerequisites/library/openshift_facts.py
@@ -1,0 +1,1 @@
+/usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py

--- a/roles/master-prerequisites/tasks/main.yaml
+++ b/roles/master-prerequisites/tasks/main.yaml
@@ -1,9 +1,6 @@
 ---
-- block:
-  - name: Install git
+- name: Install git
     package:
-      name: "{{ item }}"
+      name: git
       state: latest
-    with_items:
-    - git
   when: not openshift.common.is_atomic | bool

--- a/roles/master-prerequisites/tasks/main.yaml
+++ b/roles/master-prerequisites/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Install git
-    package:
-      name: git
-      state: latest
+  package:
+    name: git
+    state: latest
   when: not openshift.common.is_atomic | bool

--- a/roles/master-prerequisites/tasks/main.yaml
+++ b/roles/master-prerequisites/tasks/main.yaml
@@ -5,5 +5,5 @@
       name: "{{ item }}"
       state: latest
     with_items:
-    - git 
+    - git
   when: not openshift.common.is_atomic | bool

--- a/roles/master-prerequisites/tasks/main.yaml
+++ b/roles/master-prerequisites/tasks/main.yaml
@@ -1,0 +1,9 @@
+---
+- block:
+  - name: Install git
+    package:
+      name: "{{ item }}"
+      state: latest
+    with_items:
+    - git 
+  when: not openshift.common.is_atomic | bool


### PR DESCRIPTION
When running the validation testing in a containerized environment git is not installed which causes issues when attempting to deploy the validation project.