### PR TITLE
Add 'ProxyCommand none' to bastion for ssh config

### DIFF
--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -57,6 +57,7 @@ Host bastion
      Hostname                   bastion.sysdeseng.com
      user                       ec2-user
      StrictHostKeyChecking      no
+     ProxyCommand               none
      CheckHostIP                no
      ForwardAgent               yes
      IdentityFile               /path/to/ssh/key


### PR DESCRIPTION
Adds ProxyCommand none, otherwise I was finding it seemed to behave recursively in terms of proxying.