### PR TITLE
8443 should be removed since we are defaulting to https

### DIFF
--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -72,7 +72,7 @@ export AWS_SECRET_ACCESS_KEY=bar
 ```
 
 ### GitHub Authentication
-GitHub authentication is the default authentication mechanism used for this reference architecture. GitHub authentication requires an OAuth application to be created. The values should reflect the hosted zone defined in Route53 for example the Homepage URL would be https://openshift-master.sysdeseng.com and Authorization callback URL is https://openshift-master.sysdeseng.com:8443/oauth2callback/github.
+GitHub authentication is the default authentication mechanism used for this reference architecture. GitHub authentication requires an OAuth application to be created. The values should reflect the hosted zone defined in Route53 for example the Homepage URL would be https://openshift-master.sysdeseng.com and Authorization callback URL is https://openshift-master.sysdeseng.com/oauth2callback/github.
 
 ### Region
 The default region is us-east-1 but can be changed when running the ose-on-aws script by specifying --region=us-west-2 for example. The region must contain at least 3 Availability Zones.


### PR DESCRIPTION
If port 8443 is used a redirect_uri_mismatch during OAuth flow from Github will happen, which prevents logging into the Openshift Console.