### PR TITLE
Migrating to deployment manager, part 1

### DIFF
--- a/reference-architecture/gce-cli/ansible-config.yml.tpl
+++ b/reference-architecture/gce-cli/ansible-config.yml.tpl
@@ -6,10 +6,10 @@ openshift_master_cluster_hostname: ${INTERNAL_MASTER_DNS_NAME}
 console_port: ${CONSOLE_PORT}
 openshift_hosted_router_replicas: ${INFRA_NODE_INSTANCE_GROUP_SIZE}
 openshift_hosted_registry_replicas: ${INFRA_NODE_INSTANCE_GROUP_SIZE}
-openshift_deployment_type: openshift-enterprise
+deployment_type: openshift-enterprise
 ansible_pkg_mgr: yum
 gcs_registry_bucket: ${REGISTRY_BUCKET}
 gce_project_id: ${GCLOUD_PROJECT}
-gce_network_name: ${OCP_NETWORK}
+gce_network_name: ${OCP_PREFIX}-${OCP_NETWORK}
 openshift_master_identity_providers: ${OCP_IDENTITY_PROVIDERS}
 openshift_sdn: ${OPENSHIFT_SDN}

--- a/reference-architecture/gce-cli/config.sh.example
+++ b/reference-architecture/gce-cli/config.sh.example
@@ -4,11 +4,11 @@
 # Path to a RHEL image on local machine, downloaded from Red Hat Customer Portal
 RHEL_IMAGE_PATH="${HOME}/Downloads/rhel-guest-image-7.3-35.x86_64.qcow2"
 
-# Choose to delete or retain the unregistered image
-DELETE_IMAGE=true
+# Choose to delete or retain the clean image
+DELETE_IMAGE='false'
 
-# Choose to delete or retain the registered image
-REGISTERED_IMAGE_DELETE=true
+# Choose to delete or retain the golf image
+DELETE_GOLD_IMAGE='true'
 
 # Username and password for Red Hat Customer Portal
 RH_USERNAME='user@example.com'
@@ -35,82 +35,51 @@ OCP_APPS_DNS_NAME="apps.${DNS_DOMAIN}"
 MASTER_HTTPS_CERT_FILE="${HOME}/master.${DNS_DOMAIN}.pem"
 MASTER_HTTPS_KEY_FILE="${HOME}/master.${DNS_DOMAIN}.key"
 
+# Prefix for every resource name deployed
+OCP_PREFIX='ocp'
+
 # OpenShift Identity providers. This is Google oauth example (hosted_domain is optional and restricts login to users only from the specified domain)
 OCP_IDENTITY_PROVIDERS='[ {"name": "google", "kind": "GoogleIdentityProvider", "login": "true", "challenge": "false", "mapping_method": "claim", "client_id": "xxx-yyy.apps.googleusercontent.com", "client_secret": "zzz", "hosted_domain": "example.com"} ]'
 
-# OpenShift SDN selection (default is 'openshift-ovs-subnet')
+# OpenShift SDN selection (options are 'openshift-ovs-subnet', 'openshift-ovs-multitenant')
 OPENSHIFT_SDN='openshift-ovs-subnet'
 
 ## DEFAULT VALUES ##
 
 OCP_VERSION='3.4'
 
-CONSOLE_PORT='443'
-
-OCP_NETWORK='ocp-network'
-
-MASTER_MACHINE_TYPE='n1-standard-2'
-NODE_MACHINE_TYPE='n1-standard-2'
-INFRA_NODE_MACHINE_TYPE='n1-standard-2'
-BASTION_MACHINE_TYPE='n1-standard-1'
-
-MASTER_INSTANCE_TEMPLATE='master-template'
-NODE_INSTANCE_TEMPLATE='node-template'
-INFRA_NODE_INSTANCE_TEMPLATE='infra-node-template'
-
-BASTION_INSTANCE='bastion'
-
-MASTER_INSTANCE_GROUP='ocp-master'
-# How many instances should be created for this group
+# How many instances should be created for each group
 MASTER_INSTANCE_GROUP_SIZE='3'
-MASTER_NAMED_PORT_NAME='web-console'
-INFRA_NODE_INSTANCE_GROUP='ocp-infra'
-INFRA_NODE_INSTANCE_GROUP_SIZE='2'
-NODE_INSTANCE_GROUP='ocp-node'
+INFRA_NODE_INSTANCE_GROUP_SIZE='3'
 NODE_INSTANCE_GROUP_SIZE='2'
 
+BASTION_MACHINE_TYPE='n1-standard-1'
+MASTER_MACHINE_TYPE='n1-standard-2'
+NODE_MACHINE_TYPE='n1-standard-2'
+
+BASTION_DISK_SIZE='20'
+MASTER_BOOT_DISK_SIZE='35'
+NODE_BOOT_DISK_SIZE='25'
 NODE_DOCKER_DISK_SIZE='25'
-NODE_DOCKER_DISK_POSTFIX='-docker'
 NODE_OPENSHIFT_DISK_SIZE='50'
-NODE_OPENSHIFT_DISK_POSTFIX='-openshift'
 
-MASTER_NETWORK_LB_HEALTH_CHECK='master-network-lb-health-check'
-MASTER_NETWORK_LB_POOL='master-network-lb-pool'
-MASTER_NETWORK_LB_IP='master-network-lb-ip'
-MASTER_NETWORK_LB_RULE='master-network-lb-rule'
+NETWORK_DEPLOYMENT='deployment-net'
+CORE_DEPLOYMENT='deployment-core'
 
-MASTER_SSL_LB_HEALTH_CHECK='master-ssl-lb-health-check'
-MASTER_SSL_LB_BACKEND='master-ssl-lb-backend'
-MASTER_SSL_LB_IP='master-ssl-lb-ip'
+OCP_NETWORK='network'
+
 MASTER_SSL_LB_CERT='master-ssl-lb-cert'
-MASTER_SSL_LB_TARGET='master-ssl-lb-target'
-MASTER_SSL_LB_RULE='master-ssl-lb-rule'
 
-ROUTER_NETWORK_LB_HEALTH_CHECK='router-network-lb-health-check'
-ROUTER_NETWORK_LB_POOL='router-network-lb-pool'
-ROUTER_NETWORK_LB_IP='router-network-lb-ip'
-ROUTER_NETWORK_LB_RULE='router-network-lb-rule'
-
-IMAGE_BUCKET="${GCLOUD_PROJECT}-rhel-guest-raw-image"
-REGISTRY_BUCKET="${GCLOUD_PROJECT}-openshift-docker-registry"
-
-TEMP_INSTANCE='ocp-rhel-temp'
-
-GOOGLE_CLOUD_SDK_VERSION='134.0.0'
-
-# Firewall rules in a form:
-# ['name']='parameters for "gcloud compute firewall-rules create"'
-# For all possible parameters see: gcloud compute firewall-rules create --help
-declare -A FW_RULES=(
-    ['icmp']='--allow icmp'
-    ['ssh-external']='--allow tcp:22 --target-tags ssh-external'
-    ['ssh-internal']='--allow tcp:22 --source-tags bastion'
-    ['master-internal']='--allow tcp:8053,udp:8053 --source-tags ocp --target-tags ocp-master'
-    ['master-internal-etcd']='--allow tcp:2379,tcp:2380 --source-tags ocp-master --target-tags ocp-master'
-    ['master-external']="--allow tcp:${CONSOLE_PORT} --target-tags ocp-master"
-    ['node-internal-sdn']='--allow udp:4789 --source-tags ocp-node,ocp-infra-node --target-tags ocp-node,ocp-infra-node'
-    ['node-internal-kubelet']='--allow tcp:10250 --source-tags ocp-master --target-tags ocp-node,ocp-infra-node'
-    ['infra-node-internal']='--allow tcp:5000 --source-tags ocp-node,ocp-infra-node --target-tags ocp-infra-node'
-    ['infra-node-external']='--allow tcp:80,tcp:443 --target-tags ocp-infra-node'
-)
 BASTION_SSH_FW_RULE='bastion-ssh-to-external-ip'
+
+IMAGE_BUCKET="${GCLOUD_PROJECT}-${OCP_PREFIX}-rhel-guest-raw-image"
+REGISTRY_BUCKET="${GCLOUD_PROJECT}-${OCP_PREFIX}-registry-bucket"
+
+TEMP_INSTANCE='rhel-temp'
+
+GOOGLE_CLOUD_SDK_VERSION='146.0.0'
+
+# Only 443 is supported
+CONSOLE_PORT='443'
+
+SSH_CONFIG_FILE="${HOME}/.ssh/config"

--- a/reference-architecture/gce-cli/config.sh.example
+++ b/reference-architecture/gce-cli/config.sh.example
@@ -7,7 +7,7 @@ RHEL_IMAGE_PATH="${HOME}/Downloads/rhel-guest-image-7.3-35.x86_64.qcow2"
 # Choose to delete or retain the clean image
 DELETE_IMAGE='false'
 
-# Choose to delete or retain the golf image
+# Choose to delete or retain the gold image
 DELETE_GOLD_IMAGE='true'
 
 # Username and password for Red Hat Customer Portal

--- a/reference-architecture/gce-cli/deployment-manager/.gitignore
+++ b/reference-architecture/gce-cli/deployment-manager/.gitignore
@@ -1,0 +1,2 @@
+deployment-net-config.yml
+deployment-core-config.yml

--- a/reference-architecture/gce-cli/deployment-manager/deployment-core-config.yml.tpl
+++ b/reference-architecture/gce-cli/deployment-manager/deployment-core-config.yml.tpl
@@ -1,0 +1,21 @@
+imports:
+- path: deployment-core.jinja
+resources:
+- name: deployment-core
+  type: deployment-core.jinja
+  properties:
+    prefix: ${OCP_PREFIX}
+    project: ${GCLOUD_PROJECT}
+    region: ${GCLOUD_REGION}
+    zone: ${GCLOUD_ZONE}
+    gold_image: ${GOLD_IMAGE}
+    console_port: ${CONSOLE_PORT}
+    bastion_machine_type: ${BASTION_MACHINE_TYPE}
+    bastion_disk_size: ${BASTION_DISK_SIZE}
+    master_machine_type: ${MASTER_MACHINE_TYPE}
+    master_boot_disk_size: ${MASTER_BOOT_DISK_SIZE}
+    node_machine_type: ${NODE_MACHINE_TYPE}
+    node_boot_disk_size: ${NODE_BOOT_DISK_SIZE}
+    master_instance_group_size: ${MASTER_INSTANCE_GROUP_SIZE}
+    infra_node_instance_group_size: ${INFRA_NODE_INSTANCE_GROUP_SIZE}
+    node_instance_group_size: ${NODE_INSTANCE_GROUP_SIZE}

--- a/reference-architecture/gce-cli/deployment-manager/deployment-core.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/deployment-core.jinja
@@ -1,0 +1,294 @@
+resources:
+- name: {{ properties['prefix'] }}-bastion
+  properties:
+    disks:
+    - autoDelete: true
+      boot: true
+      deviceName: persistent-disk-0
+      index: 0
+      interface: SCSI
+      mode: READ_WRITE
+      type: PERSISTENT
+      initializeParams:
+        sourceImage: global/images/{{ properties['gold_image'] }}
+        diskSizeGb: {{ properties['bastion_disk_size'] }}
+        diskType: zones/{{ properties['zone'] }}/diskTypes/pd-ssd
+    machineType: zones/{{ properties['zone'] }}/machineTypes/{{ properties['bastion_machine_type'] }}
+    metadata: {}
+    networkInterfaces:
+    - accessConfigs:
+      - name: external-nat
+        type: ONE_TO_ONE_NAT
+      name: nic0
+      network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+    scheduling:
+      automaticRestart: true
+      onHostMaintenance: MIGRATE
+      preemptible: false
+    serviceAccounts:
+    - scopes:
+      - https://www.googleapis.com/auth/cloud.useraccounts.readonly
+      - https://www.googleapis.com/auth/compute
+      - https://www.googleapis.com/auth/devstorage.read_write
+      - https://www.googleapis.com/auth/logging.write
+      - https://www.googleapis.com/auth/monitoring.write
+      - https://www.googleapis.com/auth/service.management.readonly
+      - https://www.googleapis.com/auth/servicecontrol
+    tags:
+      items:
+      - {{ properties['prefix'] }}-bastion
+      - {{ properties['prefix'] }}-ssh-external
+    zone: {{ properties['zone'] }}
+  type: compute.v1.instance
+- name: {{ properties['prefix'] }}-master-template
+  properties:
+    description: ''
+    properties:
+      canIpForward: false
+      disks:
+      - autoDelete: true
+        boot: true
+        initializeParams:
+          diskSizeGb: {{ properties['master_boot_disk_size'] }}
+          diskType: pd-ssd
+          sourceImage: global/images/{{ properties['gold_image'] }}
+        mode: READ_WRITE
+        type: PERSISTENT
+      machineType: {{ properties['master_machine_type'] }}
+      metadata: {}
+      networkInterfaces:
+      - accessConfigs:
+        - name: external-nat
+          type: ONE_TO_ONE_NAT
+        network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+      scheduling:
+        automaticRestart: true
+        onHostMaintenance: MIGRATE
+        preemptible: false
+      serviceAccounts:
+      - scopes:
+        - https://www.googleapis.com/auth/cloud.useraccounts.readonly
+        - https://www.googleapis.com/auth/compute
+        - https://www.googleapis.com/auth/devstorage.read_only
+        - https://www.googleapis.com/auth/logging.write
+        - https://www.googleapis.com/auth/monitoring.write
+        - https://www.googleapis.com/auth/service.management.readonly
+        - https://www.googleapis.com/auth/servicecontrol
+      tags:
+        items:
+        - {{ properties['prefix'] }}
+        - {{ properties['prefix'] }}-master
+  type: compute.v1.instanceTemplate
+- name: {{ properties['prefix'] }}-infra-node-template
+  properties:
+    description: ''
+    properties:
+      canIpForward: false
+      disks:
+      - autoDelete: true
+        boot: true
+        initializeParams:
+          diskSizeGb: {{ properties['node_boot_disk_size'] }}
+          diskType: pd-ssd
+          sourceImage: global/images/{{ properties['gold_image'] }}
+        mode: READ_WRITE
+        type: PERSISTENT
+      machineType: {{ properties['node_machine_type'] }}
+      metadata: {}
+      networkInterfaces:
+      - accessConfigs:
+        - name: external-nat
+          type: ONE_TO_ONE_NAT
+        network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+      scheduling:
+        automaticRestart: true
+        onHostMaintenance: MIGRATE
+        preemptible: false
+      serviceAccounts:
+      - scopes:
+        - https://www.googleapis.com/auth/cloud.useraccounts.readonly
+        - https://www.googleapis.com/auth/compute
+        - https://www.googleapis.com/auth/devstorage.read_write
+        - https://www.googleapis.com/auth/logging.write
+        - https://www.googleapis.com/auth/monitoring.write
+        - https://www.googleapis.com/auth/service.management.readonly
+        - https://www.googleapis.com/auth/servicecontrol
+      tags:
+        items:
+        - {{ properties['prefix'] }}
+        - {{ properties['prefix'] }}-infra-node
+  type: compute.v1.instanceTemplate
+- name: {{ properties['prefix'] }}-node-template
+  properties:
+    description: ''
+    properties:
+      canIpForward: false
+      disks:
+      - autoDelete: true
+        boot: true
+        initializeParams:
+          diskSizeGb: {{ properties['node_boot_disk_size'] }}
+          diskType: pd-ssd
+          sourceImage: global/images/{{ properties['gold_image'] }}
+        mode: READ_WRITE
+        type: PERSISTENT
+      machineType: {{ properties['node_machine_type'] }}
+      metadata: {}
+      networkInterfaces:
+      - accessConfigs:
+        - name: external-nat
+          type: ONE_TO_ONE_NAT
+        network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+      scheduling:
+        automaticRestart: true
+        onHostMaintenance: MIGRATE
+        preemptible: false
+      serviceAccounts:
+      - scopes:
+        - https://www.googleapis.com/auth/cloud.useraccounts.readonly
+        - https://www.googleapis.com/auth/compute
+        - https://www.googleapis.com/auth/devstorage.read_only
+        - https://www.googleapis.com/auth/logging.write
+        - https://www.googleapis.com/auth/monitoring.write
+        - https://www.googleapis.com/auth/service.management.readonly
+        - https://www.googleapis.com/auth/servicecontrol
+      tags:
+        items:
+        - {{ properties['prefix'] }}
+        - {{ properties['prefix'] }}-node
+  type: compute.v1.instanceTemplate
+- name: {{ properties['prefix'] }}-master
+  properties:
+    baseInstanceName: {{ properties['prefix'] }}-master
+    instanceTemplate: $(ref.{{ properties['prefix'] }}-master-template.selfLink)
+    namedPorts:
+    - name: {{ properties['prefix'] }}-web-console
+      port: {{ properties['console_port'] }}
+    targetPools:
+    - $(ref.{{ properties['prefix'] }}-master-network-lb-pool.selfLink)
+    targetSize: {{ properties['master_instance_group_size'] }}
+    zone: {{ properties['zone'] }}
+  type: compute.v1.instanceGroupManager
+- name: {{ properties['prefix'] }}-infra-node
+  properties:
+    baseInstanceName: {{ properties['prefix'] }}-infra-node
+    instanceTemplate: $(ref.{{ properties['prefix'] }}-infra-node-template.selfLink)
+    targetPools:
+    - $(ref.{{ properties['prefix'] }}-router-network-lb-pool.selfLink)
+    targetSize: {{ properties['infra_node_instance_group_size'] }}
+    zone: {{ properties['zone'] }}
+  type: compute.v1.instanceGroupManager
+- name: {{ properties['prefix'] }}-node
+  properties:
+    baseInstanceName: {{ properties['prefix'] }}-node
+    instanceTemplate: $(ref.{{ properties['prefix'] }}-node-template.selfLink)
+    targetSize: {{ properties['node_instance_group_size'] }}
+    zone: {{ properties['zone'] }}
+  type: compute.v1.instanceGroupManager
+- name: {{ properties['prefix'] }}-master-ssl-lb-health-check
+  properties:
+    checkIntervalSec: 5
+    description: ''
+    healthyThreshold: 2
+    httpsHealthCheck:
+      port: {{ properties['console_port'] }}
+      proxyHeader: NONE
+      requestPath: /healthz
+    timeoutSec: 5
+    type: HTTPS
+    unhealthyThreshold: 2
+  type: compute.v1.healthCheck
+- name: {{ properties['prefix'] }}-master-network-lb-health-check
+  properties:
+    checkIntervalSec: 5
+    description: ''
+    healthyThreshold: 2
+    host: ''
+    port: 8080
+    requestPath: /healthz
+    timeoutSec: 5
+    unhealthyThreshold: 2
+  type: compute.v1.httpHealthCheck
+- name: {{ properties['prefix'] }}-router-network-lb-health-check
+  properties:
+    checkIntervalSec: 5
+    description: ''
+    healthyThreshold: 2
+    host: ''
+    port: 1936
+    requestPath: /healthz
+    timeoutSec: 5
+    unhealthyThreshold: 2
+  type: compute.v1.httpHealthCheck
+- name: {{ properties['prefix'] }}-master-ssl-lb-backend
+  properties:
+    healthChecks:
+    - $(ref.{{ properties['prefix'] }}-master-ssl-lb-health-check.selfLink)
+    loadBalancingScheme: EXTERNAL
+    portName: {{ properties['prefix'] }}-web-console
+    protocol: SSL
+    backends:
+    - group: $(ref.{{ properties['prefix'] }}-master.instanceGroup)
+  type: compute.v1.backendService
+- name: {{ properties['prefix'] }}-master-ssl-lb-target
+  properties:
+    proxyHeader: NONE
+    service: $(ref.{{ properties['prefix'] }}-master-ssl-lb-backend.selfLink)
+    sslCertificates:
+    - projects/{{env['project']}}/global/sslCertificates/{{ properties['prefix'] }}-master-ssl-lb-cert
+  type: compute.v1.targetSslProxy
+- name: {{ properties['prefix'] }}-master-ssl-lb-ip
+  type: compute.v1.globalAddress
+- name: {{ properties['prefix'] }}-master-ssl-lb-rule
+  properties:
+    IPProtocol: TCP
+    description: ''
+    IPAddress: $(ref.{{ properties['prefix'] }}-master-ssl-lb-ip.selfLink)
+    loadBalancingScheme: EXTERNAL
+    portRange: {{ properties['console_port'] }}-{{ properties['console_port'] }}
+    target: $(ref.{{ properties['prefix'] }}-master-ssl-lb-target.selfLink)
+  type: compute.v1.globalForwardingRule
+- name: {{ properties['prefix'] }}-master-network-lb-pool
+  properties:
+    description: ''
+    healthChecks:
+    - $(ref.{{ properties['prefix'] }}-master-network-lb-health-check.selfLink)
+    region: {{ properties['region'] }}
+  type: compute.v1.targetPool
+- name: {{ properties['prefix'] }}-master-network-lb-ip
+  properties:
+    description: ''
+    region: {{ properties['region'] }}
+  type: compute.v1.address
+- name: {{ properties['prefix'] }}-master-network-lb-rule
+  properties:
+    IPProtocol: TCP
+    description: ''
+    IPAddress: $(ref.{{ properties['prefix'] }}-master-network-lb-ip.selfLink)
+    loadBalancingScheme: EXTERNAL
+    portRange: {{ properties['console_port'] }}-{{ properties['console_port'] }}
+    region: {{ properties['region'] }}
+    target: $(ref.{{ properties['prefix'] }}-master-network-lb-pool.selfLink)
+  type: compute.v1.forwardingRule
+- name: {{ properties['prefix'] }}-router-network-lb-pool
+  properties:
+    description: ''
+    healthChecks:
+    - $(ref.{{ properties['prefix'] }}-router-network-lb-health-check.selfLink)
+    region: {{ properties['region'] }}
+  type: compute.v1.targetPool
+- name: {{ properties['prefix'] }}-router-network-lb-ip
+  properties:
+    description: ''
+    region: {{ properties['region'] }}
+  type: compute.v1.address
+- name: {{ properties['prefix'] }}-router-network-lb-rule
+  properties:
+    IPProtocol: TCP
+    description: ''
+    IPAddress: $(ref.{{ properties['prefix'] }}-router-network-lb-ip.selfLink)
+    loadBalancingScheme: EXTERNAL
+    portRange: 80-443
+    region: {{ properties['region'] }}
+    target: $(ref.{{ properties['prefix'] }}-router-network-lb-pool.selfLink)
+  type: compute.v1.forwardingRule

--- a/reference-architecture/gce-cli/deployment-manager/deployment-net-config.yml.tpl
+++ b/reference-architecture/gce-cli/deployment-manager/deployment-net-config.yml.tpl
@@ -1,0 +1,9 @@
+imports:
+- path: deployment-net.jinja
+resources:
+- name: deployment-net
+  type: deployment-net.jinja
+  properties:
+    prefix: ${OCP_PREFIX}
+    region: ${GCLOUD_REGION}
+    console_port: ${CONSOLE_PORT}

--- a/reference-architecture/gce-cli/deployment-manager/deployment-net.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/deployment-net.jinja
@@ -1,0 +1,145 @@
+resources:
+- name: {{ properties['prefix'] }}-network
+  properties:
+    autoCreateSubnetworks: true
+    subnetworks:
+    - projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-network
+    x_gcloud_mode: auto
+  type: compute.v1.network
+- name: {{ properties['prefix'] }}-icmp
+  properties:
+    allowed:
+    - IPProtocol: icmp
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceRanges:
+    - 0.0.0.0/0
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-ssh-external
+  properties:
+    allowed:
+    - IPProtocol: tcp
+      ports:
+      - '22'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceRanges:
+    - 0.0.0.0/0
+    targetTags:
+    - {{ properties['prefix'] }}-ssh-external
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-ssh-internal
+  properties:
+    allowed:
+    - IPProtocol: tcp
+      ports:
+      - '22'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceTags:
+    - {{ properties['prefix'] }}-bastion
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-master-internal-dns
+  properties:
+    allowed:
+    - IPProtocol: udp
+      ports:
+      - '8053'
+    - IPProtocol: tcp
+      ports:
+      - '8053'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceTags:
+    - {{ properties['prefix'] }}
+    targetTags:
+    - {{ properties['prefix'] }}-master
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-master-internal-etcd
+  properties:
+    allowed:
+    - IPProtocol: tcp
+      ports:
+      - '2379'
+    - IPProtocol: tcp
+      ports:
+      - '2380'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceTags:
+    - {{ properties['prefix'] }}-master
+    targetTags:
+    - {{ properties['prefix'] }}-master
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-master-external
+  properties:
+    allowed:
+    - IPProtocol: tcp
+      ports:
+      - {{ properties['console_port'] }}
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceRanges:
+    - 0.0.0.0/0
+    targetTags:
+    - {{ properties['prefix'] }}-master
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-node-internal-sdn
+  properties:
+    allowed:
+    - IPProtocol: udp
+      ports:
+      - '4789'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceTags:
+    - {{ properties['prefix'] }}-node
+    - {{ properties['prefix'] }}-infra-node
+    targetTags:
+    - {{ properties['prefix'] }}-node
+    - {{ properties['prefix'] }}-infra-node
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-node-internal-kubelet
+  properties:
+    allowed:
+    - IPProtocol: tcp
+      ports:
+      - '10250'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceTags:
+    - {{ properties['prefix'] }}-master
+    targetTags:
+    - {{ properties['prefix'] }}-node
+    - {{ properties['prefix'] }}-infra-node
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-infra-node-internal
+  properties:
+    allowed:
+    - IPProtocol: tcp
+      ports:
+      - '5000'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceTags:
+    - {{ properties['prefix'] }}-node
+    - {{ properties['prefix'] }}-infra-node
+    targetTags:
+    - {{ properties['prefix'] }}-infra-node
+  type: compute.v1.firewall
+- name: {{ properties['prefix'] }}-infra-node-external
+  properties:
+    allowed:
+    - IPProtocol: tcp
+      ports:
+      - '80'
+    - IPProtocol: tcp
+      ports:
+      - '443'
+    description: ''
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    sourceRanges:
+    - 0.0.0.0/0
+    targetTags:
+    - {{ properties['prefix'] }}-infra-node
+  type: compute.v1.firewall


### PR DESCRIPTION
This is a first step in migrating the gcp ref. arch. away from shell script to
Google's gcp deployment manager and ansible. Most of the resources is now
migrated, more complicated resources will be migrated later. Naming was redone
- before, it was possible to choose arbitrary name for almost any resource -
now it's done by changing the 'prefix'. This way, it should be possible to
deploy multiple clusters under single account by choosing different prefix.