### PR TITLE
Handle non standard OCP_PREFIX with GCE setup

### DIFF
--- a/reference-architecture/gce-ansible/inventory/gce/hosts/gce.py
+++ b/reference-architecture/gce-ansible/inventory/gce/hosts/gce.py
@@ -330,6 +330,7 @@ class GceInventory(object):
             else: groups[zone] = [name]
 
             tags = node.extra['tags']
+            tag_prefix = os.environ.get('OCP_PREFIX', 'ocp')
             for t in tags:
                 if t.startswith('group-'):
                     tag = t[6:]
@@ -337,6 +338,11 @@ class GceInventory(object):
                     tag = 'tag_%s' % t
                 if groups.has_key(tag): groups[tag].append(name)
                 else: groups[tag] = [name]
+                if tag_prefix != 'ocp' and t.startswith(tag_prefix):
+                    pos = t.find('-') # we use this in the deployment manager in gcloud.sh
+                    tag = 'tag_ocp-%s' % t[pos+1:]
+                    if groups.has_key(tag): groups[tag].append(name)
+                    else: groups[tag] = [name]
 
             net = node.extra['networkInterfaces'][0]['network'].split('/')[-1]
             net = 'network_%s' % net

--- a/reference-architecture/gce-ansible/inventory/gce/hosts/gce.py
+++ b/reference-architecture/gce-ansible/inventory/gce/hosts/gce.py
@@ -339,8 +339,7 @@ class GceInventory(object):
                 if groups.has_key(tag): groups[tag].append(name)
                 else: groups[tag] = [name]
                 if tag_prefix != 'ocp' and t.startswith(tag_prefix):
-                    pos = t.find('-') # we use this in the deployment manager in gcloud.sh
-                    tag = 'tag_ocp-%s' % t[pos+1:]
+                    tag = 'tag_ocp-%s' % t[len(tag_prefix)+1:]
                     if groups.has_key(tag): groups[tag].append(name)
                     else: groups[tag] = [name]
 


### PR DESCRIPTION
If someone sets a non-default OCP_PREFIX the following stages such as r/reference-architecture/gce-ansible/playbooks/create-inventory-file.yaml and the /reference-architecture/gce-ansible/playbooks/roles/instance-groups/tasks/main.yaml that rely on these groups fail. This patch takes an approach of handling this at the inventory generation phase to account for a non-standard prefix. 