### PR TITLE
remove ssh keys for new instances on heat stack create

### DIFF
--- a/reference-architecture/osp-dns/deploy-dns.yaml
+++ b/reference-architecture/osp-dns/deploy-dns.yaml
@@ -69,6 +69,13 @@
       ansible_user: "{{ ssh_user }}"
     with_items: "{{ stack_output.slaves }}"
 
+  - name: Clear saved SSH keys
+    known_hosts:
+      name: "{{ item }}"
+      state: absent
+    with_items: "{{ groups['all'] }}"
+    when: stack_check.rc != 0
+
   - name: Wait for the deployed servers
     wait_for:
       host: "{{ item }}"


### PR DESCRIPTION
On creating new servers in a heat stack, remove any old SSH keys from the localhost known_hosts file.
This will prevent erroneous messages from SSH when ansible attempts to log into the instances for the first time.