### PR TITLE
adding epel due to error

### DIFF
--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -344,6 +344,8 @@ gcloud --project "$GCLOUD_PROJECT" compute ssh "cloud-user@${OCP_PREFIX}-bastion
         --enable=\"rhel-7-server-extras-rpms\" \
         --enable=\"rhel-7-server-ose-${OCP_VERSION}-rpms\";
 
+    rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm;
+
     yum install -y git python-libcloud atomic-openshift-utils;
 
     if ! grep -q \"export GCE_PROJECT=${GCLOUD_PROJECT}\" /etc/profile.d/ocp.sh 2>/dev/null; then


### PR DESCRIPTION
Without epel enabled on the bastion the following occurs.

```
ERROR! Attempted to execute "inventory/gce/hosts/gce.py" as inventory script: Inventory script (inventory/gce/hosts/gce.py) had an execution error: GCE inventory script requires libcloud >= 0.13
```

Adding epel to gcloud.sh bastion resolves this error.  

