### PR TITLE
[GCP] Updated ssl-certificate role

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/roles/ssl-certificate/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/ssl-certificate/tasks/main.yaml
@@ -1,69 +1,70 @@
 ---
-- block:
-  - name: stat key file
-    stat:
-      path: '{{ master_https_key_file }}'
-    register: https_key_file
-
-  - name: stat cert file
-    stat:
-      path: '{{ master_https_cert_file }}'
-    register: https_cert_file
-
-  - name: check key file
-    assert:
-      that:
-      - 'https_key_file.stat.isreg is defined'
-      - 'https_key_file.stat.isreg'
-      - 'https_key_file.stat.readable'
-      msg: Master HTTPS key file must exist and it must be readable
-
-  - name: check cert file
-    assert:
-      that:
-      - 'https_cert_file.stat.isreg is defined'
-      - 'https_cert_file.stat.isreg'
-      - 'https_cert_file.stat.readable'
-      msg: Master HTTPS certificate file must exist and it must be readable
-
-  - name: set certificate files facts
-    set_fact:
-      ssl_key: '{{ master_https_key_file }}'
-      ssl_cert: '{{ master_https_cert_file }}'
-      ssl_selfsigned: False
-  when:
-  - master_https_key_file is defined
-  - master_https_key_file
-  - master_https_cert_file is defined
-  - master_https_cert_file
-
-- block:
-  - name: set certificate files facts
-    set_fact:
-      ssl_key: /tmp/ocp-ssl.key
-      ssl_cert: /tmp/ocp-ssl.crt
-      ssl_selfsigned: True
-
-  - name: create self signed certificate
-    command: openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -subj '/C=US/L=Raleigh/O={{ dns_domain }}/CN={{ master_dns_name }}' -keyout '{{ ssl_key }}' -out '{{ ssl_cert }}' creates='{{ ssl_cert }}'
-  when: master_https_key_file is not defined or not master_https_key_file or
-        master_https_cert_file is not defined or not master_https_cert_file
-
 - name: check if ssl certificate exists
   command: gcloud --project {{ gcloud_project }} compute ssl-certificates describe {{ ssl_lb_cert_with_prefix }}
   register: ssl_cert_exists
   changed_when: false
   ignore_errors: true
 
-- name: create ssl certificate
-  command: gcloud --project {{ gcloud_project }} compute ssl-certificates create {{ ssl_lb_cert_with_prefix }} --private-key "{{ ssl_key }}" --certificate "{{ ssl_cert }}"
-  when: ssl_cert_exists | failed
+- block:
+  - block:
+    - name: stat key file
+      stat:
+        path: '{{ master_https_key_file }}'
+      register: https_key_file
 
-- name: delete self-signed certificate
-  file:
-    path: '{{ item }}'
-    state: absent
-  with_items:
-  - '{{ ssl_key }}'
-  - '{{ ssl_cert }}'
-  when: ssl_selfsigned
+    - name: stat cert file
+      stat:
+        path: '{{ master_https_cert_file }}'
+      register: https_cert_file
+
+    - name: check key file
+      assert:
+        that:
+        - 'https_key_file.stat.exists'
+        - 'https_key_file.stat.readable'
+        msg: Master HTTPS key file must exist and it must be readable
+
+    - name: check cert file
+      assert:
+        that:
+        - 'https_cert_file.stat.exists'
+        - 'https_cert_file.stat.readable'
+        msg: Master HTTPS certificate file must exist and it must be readable
+
+    - name: set certificate files facts
+      set_fact:
+        ssl_key: '{{ master_https_key_file }}'
+        ssl_cert: '{{ master_https_cert_file }}'
+        ssl_selfsigned: false
+    when:
+    - master_https_key_file is defined
+    - master_https_key_file is not none
+    - master_https_key_file | trim != ''
+    - master_https_cert_file is defined
+    - master_https_cert_file is not none
+    - master_https_cert_file | trim != ''
+
+  - block:
+    - name: set certificate files facts
+      set_fact:
+        ssl_key: /tmp/ocp-ssl.key
+        ssl_cert: /tmp/ocp-ssl.crt
+        ssl_selfsigned: true
+
+    - name: create self signed certificate
+      command: openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -subj '/C=US/L=Raleigh/O={{ dns_domain }}/CN={{ master_dns_name }}' -keyout '{{ ssl_key }}' -out '{{ ssl_cert }}' creates='{{ ssl_cert }}'
+    when: master_https_key_file is not defined or master_https_key_file is none or master_https_key_file | trim == '' or
+          master_https_cert_file is not defined or master_https_cert_file is none or master_https_cert_file | trim == ''
+
+  - name: create ssl certificate
+    command: gcloud --project {{ gcloud_project }} compute ssl-certificates create {{ ssl_lb_cert_with_prefix }} --private-key "{{ ssl_key }}" --certificate "{{ ssl_cert }}"
+
+  - name: delete self-signed certificate
+    file:
+      path: '{{ item }}'
+      state: absent
+    with_items:
+    - '{{ ssl_key }}'
+    - '{{ ssl_cert }}'
+    when: ssl_selfsigned
+  when: ssl_cert_exists | failed


### PR DESCRIPTION
Fix ssl-certificate role, so it doesn't fail when user provides custom
certificate, and add a check for already created ssl certificate in GCP, so the
following tasks could be skipped.

Fixes #344 