### PR TITLE
safer subscriptions until we move to openshift-ansible

### DIFF
--- a/playbooks/add-node-prerequisite.yaml
+++ b/playbooks/add-node-prerequisite.yaml
@@ -4,7 +4,7 @@
   become: yes
   serial: 1
   roles:
-    - rhsm-subscription
+    - aws-rhsm-subscription
 
 - hosts: new_nodes
   gather_facts: no

--- a/playbooks/aws-prerequisite.yaml
+++ b/playbooks/aws-prerequisite.yaml
@@ -1,0 +1,20 @@
+---
+- hosts: cluster_hosts
+  gather_facts: yes
+  become: yes
+  serial: 1
+  roles:
+  - aws-rhsm-subscription
+
+- hosts: cluster_hosts
+  gather_facts: no
+  become: yes
+  roles:
+  - rhsm-repos
+  - prerequisites
+
+- hosts: master
+  gather_facts: yes
+  become: yes
+  roles:
+  - master-prerequisites

--- a/reference-architecture/aws-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/aws-ansible/playbooks/openshift-install.yaml
@@ -19,6 +19,6 @@
   roles:
   - host-up
 
-- include: ../../../playbooks/prerequisite.yaml
+- include: ../../../playbooks/aws-prerequisite.yaml
 
 - include: openshift-setup.yaml

--- a/roles/aws-rhsm-subscription/tasks/main.yaml
+++ b/roles/aws-rhsm-subscription/tasks/main.yaml
@@ -1,0 +1,54 @@
+---
+- block:
+    - name: Allow rhsm a longer timeout to help out with subscription-manager
+      lineinfile:
+        dest: /etc/rhsm/rhsm.conf
+        line: 'server_timeout=600'
+        insertafter: '^proxy_password ='
+
+    - name: Check for sat config file
+      stat: path=/etc/rhsm/rhsm.conf.kat-backup
+      register: sat_cfg
+
+    - name: Remove satellite configuration if using RH CDN
+      command: "mv -f /etc/rhsm/rhsm.conf.kat-backup /etc/rhsm/rhsm.conf"
+      when: rhsm_user is defined and rhsm_user and sat_cfg.stat.exists == True
+      ignore_errors: yes
+
+    - name: Remove satellite SSL if using RH CDN
+      command: "rpm -e $(rpm -qa katello-ca-consumer*)"
+      when: rhsm_user is defined and rhsm_user and sat_cfg.stat.exists == True
+      ignore_errors: yes
+
+    - name: Is the host already registered?
+      command: "subscription-manager status"
+      register: subscribed
+      changed_when: no
+      ignore_errors: yes
+
+    - name: RedHat subscriptions
+      redhat_subscription:
+        username: "{{ rhsm_user }}"
+        password: "{{ rhsm_password }}"
+      when: "'Current' not in subscribed.stdout and rhsm_user is defined and rhsm_user"
+
+    - name: Retrieve the OpenShift Pool ID
+      command: subscription-manager list --available --matches="{{ rhsm_pool }}" --pool-only
+      register: openshift_pool_id
+      changed_when: False
+
+    - name: Determine if OpenShift Pool Already Attached
+      command: subscription-manager list --consumed --matches="{{ rhsm_pool }}" --pool-only
+      register: openshift_pool_attached
+      changed_when: False
+      when: openshift_pool_id.stdout == ''
+
+    - fail:
+        msg: "Unable to find pool matching {{ rhsm_pool }} in available or consumed pools"
+      when: openshift_pool_id.stdout == '' and openshift_pool_attached is defined and openshift_pool_attached.stdout == ''
+
+    - name: Attach to OpenShift Pool
+      command: subscription-manager subscribe --pool {{ openshift_pool_id.stdout_lines[0] }}
+      when: openshift_pool_id.stdout != ''
+
+  when: ansible_distribution == "RedHat"


### PR DESCRIPTION
This is the safer route to subscribe a server to rhsm. This will be the stop gap until the next openshift release which should have a fix included for us.