### PR TITLE
Update gold-image-include.yaml

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/gold-image-include.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/gold-image-include.yaml
@@ -11,7 +11,7 @@
   - meta: refresh_inventory
   - name: wait for the temp instance to come up
     wait_for:
-      host: '{{ hostvars[prefix + "-tmp-instance"]["ansible_ssh_host"] }}'
+      host: '{{ hostvars[prefix + "-tmp-instance"]["gce_public_ip"] }}'
       port: 22
       state: started
 


### PR DESCRIPTION
Currently ansible_ssh_host contains the "ocp-tmp-instance" as value (https://github.com/openshift/openshift-ansible-contrib/blob/master/reference-architecture/gce-cli/ansible/inventory/gce/hosts/gce.py#L380).

This cause the timeout of the task.

