### PR TITLE
ensure that directories exist before beginning installation

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/roles/pre-install-check/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/pre-install-check/tasks/main.yaml
@@ -3,3 +3,13 @@
   assert:
     that: "ansible_version.full | version_compare('2.2', '>=')"
     msg: "You need Ansible version 2.2.0+"
+
+- name: Validate that openshift rpms are installed or git repo has been cloned
+  stat:
+    path: /usr/share/ansible/openshift-ansible
+  register: openshift_directory
+
+- name: Fail if directory doesn't exist
+  fail:
+    msg: "The directory of /usr/share/ansible/ must contain OpenShift playbooks and roles which can be installed by rpm or git clone"
+  when: openshift_directory.stat.exists == False


### PR DESCRIPTION
Pre-flight check that will ensure that /usr/share/ansible/openshift-ansible is populated