### PR TITLE
azure.conf should be ini format, no json

### DIFF
--- a/reference-architecture/azure-ansible/bastion.sh
+++ b/reference-architecture/azure-ansible/bastion.sh
@@ -216,13 +216,11 @@ cat > /home/${AUSERNAME}/setup-azure-master.yml <<EOF
     copy:
       dest: "{{ azure_conf }}"
       content: |
-        {
-          "aadClientID" : "{{ g_aadClientId }}",
-          "aadClientSecret" : "{{ g_aadClientSecret }}",
-          "subscriptionID" : "{{ g_subscriptionId }}",
-          "tenantID" : "{{ g_tenantId }}",
-          "resourceGroup": "{{ g_resourceGroup }}",
-        }
+        aadClientID: "{{ g_aadClientId }}"
+        aadClientSecret: "{{ g_aadClientSecret }}"
+        subscriptionID: "{{ g_subscriptionId }}"
+        tenantID: "{{ g_tenantId }}"
+        resourceGroup: "{{ g_resourceGroup }}"
     notify:
     - restart atomic-openshift-master-api
     - restart atomic-openshift-master-controllers
@@ -287,13 +285,11 @@ cat > /home/${AUSERNAME}/setup-azure-node.yml <<EOF
     copy:
       dest: "{{ azure_conf }}"
       content: |
-        {
-          "aadClientID" : "{{ g_aadClientId }}",
-          "aadClientSecret" : "{{ g_aadClientSecret }}",
-          "subscriptionID" : "{{ g_subscriptionId }}",
-          "tenantID" : "{{ g_tenantId }}",
-          "resourceGroup": "{{ g_resourceGroup }}",
-        }
+        aadClientID: "{{ g_aadClientId }}"
+        aadClientSecret: "{{ g_aadClientSecret }}"
+        subscriptionID: "{{ g_subscriptionId }}"
+        tenantID: "{{ g_tenantId }}"
+        resourceGroup: "{{ g_resourceGroup }}"
     notify:
     - restart atomic-openshift-node
   - name: insert the azure disk config into the node


### PR DESCRIPTION
https://docs.openshift.com/container-platform/3.5/install_config/configuring_azure.html#azure-configuration-file
I've tried to create a PVC with the previous format and it failed with "Failed to create provisioner: Failed to get Azure Cloud Provider. GetCloudProvider returned <nil> instead" and after doing this modifications and restarting master service, it works.