### PR TITLE
ocp_tmp_instance variable

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/gold-image-include.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/gold-image-include.yaml
@@ -11,12 +11,12 @@
   - meta: refresh_inventory
   - name: wait for the temp instance to come up
     wait_for:
-      host: '{{ hostvars[prefix + "-tmp-instance"]["gce_public_ip"] }}'
+      host: '{{ ocp_tmp_instance }}'
       port: 22
       state: started
 
 - name: modify temp instance
-  hosts: '{{ prefix }}-tmp-instance'
+  hosts: '{{ ocp_tmp_instance }}'
   vars_files:
   - ../../ansible-main-config.yaml
   roles:

--- a/reference-architecture/gce-cli/ansible/playbooks/gold-image.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/gold-image.yaml
@@ -9,4 +9,6 @@
     ignore_errors: true
 
 - include: gold-image-include.yaml
+  vars:
+    ocp_tmp_instance: "{{ hostvars[prefix + '-tmp-instance']['gce_public_ip'] }}"
   when: hostvars['localhost']['gold_image_exists'] | failed


### PR DESCRIPTION
As you know, ansible_ssh_host contains the "ocp-tmp-instance" as value, which is not a valid host. Because you cannot reference the "**hostsvars**" inside  **hosts** keyword, the same fix to use the **gce_public_ip** is not applicable.

So I had to externalise the var **ocp_tmp_instance** inside **gold-image.yaml**
