### PR TITLE
Propose Get pool id maches fix.

### DIFF
--- a/roles/rhsm-subscription/tasks/main.yaml
+++ b/roles/rhsm-subscription/tasks/main.yaml
@@ -45,19 +45,19 @@
       when: "'Current' not in subscribed.stdout and rhsm_user is defined and rhsm_user"
 
     - name: Check if subscription is attached
-      command: subscription-manager list --consumed --pool-only --matches="{{ rhsm_pool }}"
+      shell: "subscription-manager list --consumed --pool-only --matches '*OpenShift*' | grep {{ rhsm_pool }}"
       register: subscription_attached
       changed_when: no
 
     - block:
         - name: Get pool id
-          shell: subscription-manager list --available --pool-only --matches="{{ rhsm_pool }}" | head -n 1
+          shell: "subscription-manager list --available --pool-only --matches '*OpenShift*' | grep {{ rhsm_pool }} | head -n 1"
           register: pool_id
           changed_when: no
 
         - name: Fail if no pool ID is returned
           fail:
-            msg: No subscription matching "{{ rhsm_pool }}" found
+            msg: "No subscription matching {{ rhsm_pool }} found"
           when: pool_id.stdout == ""
 
         - name: Attach subscription


### PR DESCRIPTION
The --matches filters only the subscription or product information.

Sample tests:

subscription-manager list --available --pool-only | grep 1234
1234

subscription-manager list --available --pool-only --matches 1234

subscription-manager list --available --pool-only --matches '*OpenShift*' | grep 1234
1234