### PR TITLE
iptables rules & proper fail

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
@@ -65,6 +65,11 @@
       state: absent
     delegate_to: localhost
 
-  - name: set fact indicating that the temp instance failed
-    set_fact:
-      tmp_instance_failed: true
+  - name: delete local ssh config for temp instance
+    include_role:
+      name: ssh-config-tmp-instance-delete
+    delegate_to: localhost
+
+  - name: fail after cleanup
+    fail:
+      msg: Failed to create gold image. Please look for an error in the output above.

--- a/reference-architecture/gce-cli/ansible/playbooks/roles/gold-image/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/gold-image/tasks/main.yaml
@@ -1,15 +1,12 @@
 ---
-- block:
-  - name: create gold image
-    include_role:
-      name: deployment-create
-    vars:
-      deployment_name: gold-image
+- name: create gold image
+  include_role:
+    name: deployment-create
+  vars:
+    deployment_name: gold-image
 
-  - name: delete temp instance disk
-    gce_pd:
-      name: '{{ prefix }}-tmp-instance'
-      zone: '{{ gcloud_zone }}'
-      state: absent
-  when: hostvars[prefix + '-tmp-instance']['tmp_instance_failed'] is not defined or
-        not hostvars[prefix + '-tmp-instance']['tmp_instance_failed']
+- name: delete temp instance disk
+  gce_pd:
+    name: '{{ prefix }}-tmp-instance'
+    zone: '{{ gcloud_zone }}'
+    state: absent

--- a/reference-architecture/gce-cli/ansible/playbooks/roles/restrict-gce-metadata/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/restrict-gce-metadata/tasks/main.yaml
@@ -13,3 +13,6 @@
 
 - name: block containers from access to the GCP metadata server
   command: iptables --wait -4 --insert FORWARD -d 169.254.169.254 -m comment --comment "Prevent containers from reaching GCP API server" -j REJECT --reject-with icmp-host-prohibited
+
+- name: save iptables rules
+  command: /usr/libexec/iptables/iptables.init save


### PR DESCRIPTION
* Save custom GCP iptables rules, so they survive reboots
* Fail after cleanup, when we couldn't create the gold image (e.g. because of invalid rhsm credentials)