### PR TITLE
lowercase rhel_image_gce to match GCP requirements

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/group_vars/all
+++ b/reference-architecture/gce-cli/ansible/playbooks/group_vars/all
@@ -11,7 +11,7 @@ gcs_registry_bucket: '{{ gcloud_project }}-{{ prefix }}-registry-bucket'
 deployment_type: '{{ openshift_deployment_type }}'
 
 rhel_image: '{{ rhel_image_path | basename | regex_replace("^(.*)\.qcow2$", "\1") }}'
-rhel_image_gce: '{{ rhel_image | replace(".", "-") | replace("_", "-") }}'
+rhel_image_gce: '{{ rhel_image | replace(".", "-") | replace("_", "-") | lower }}'
 gold_image: '{{ rhel_image_gce }}-gold'
 gold_image_family: 'rhel-guest-gold'
 


### PR DESCRIPTION
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "{u'domain': u'global', u'message': u\"Invalid value for field 'resource.name': 'CentOS-7-x86-64-GenericCloud-1704'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'\", u'reason': u'invalid'}"}