### PR TITLE
Suggest installing java-1.8.0-openjdk-headless and httpd-tools

### DIFF
--- a/reference-architecture/gce-cli/README.md
+++ b/reference-architecture/gce-cli/README.md
@@ -11,7 +11,7 @@ Described usage is for RHEL 7 based operating system.
 
 Installation of gcloud utility is interactive, usually you will want to answer positively to asked questions.
 ```
-sudo yum -y install curl python which tar qemu-img openssl git ansible python-libcloud python2-jmespath java-1.8.0-openjdk-headless
+sudo yum -y install curl python which tar qemu-img openssl git ansible python-libcloud python2-jmespath java-1.8.0-openjdk-headless httpd-tools
 curl https://sdk.cloud.google.com | bash
 exec -l $SHELL
 gcloud components install beta

--- a/reference-architecture/gce-cli/README.md
+++ b/reference-architecture/gce-cli/README.md
@@ -11,7 +11,7 @@ Described usage is for RHEL 7 based operating system.
 
 Installation of gcloud utility is interactive, usually you will want to answer positively to asked questions.
 ```
-sudo yum -y install curl python which tar qemu-img openssl git ansible python-libcloud python2-jmespath
+sudo yum -y install curl python which tar qemu-img openssl git ansible python-libcloud python2-jmespath java-1.8.0-openjdk-headless
 curl https://sdk.cloud.google.com | bash
 exec -l $SHELL
 gcloud components install beta


### PR DESCRIPTION
java-1.8.0-openjdk-headless is required when installing metrics.  Failure to do so results in a confusing message:

fatal: [osacpr00-master-p8tg]: FAILED! => {"changed": false, "failed": true, "msg": "'keytool' is unavailable. Please install java-1.8.0-openjdk-headless on the control node"}

The first few times I read this I misunderstood that this was a local check for the machine that was trying to bring up the cluster.  The message admittedly says "control node" right there on the tin but I guess I didn't make the connection.  Regardless, seems better to add it to the list of required packages.