### PR TITLE
[WIP] Install DNS config prerequisites

### DIFF
--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install prerequisites
+  package:
+    name: python-dns
+  become: true
+
 - name: "Remove any deleted DNS A records"
   nsupdate:
     key_name: "{{ item.0.key_name }}"


### PR DESCRIPTION
Ansible nsupdate module requires python-dns
installed for provisioned nodes.

Closes: https://github.com/openshift/openshift-ansible-contrib/issues/468

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>