### PR TITLE
Add profiling and skippy stdout

### DIFF
--- a/playbooks/provisioning/openstack/sample-inventory/ansible.cfg
+++ b/playbooks/provisioning/openstack/sample-inventory/ansible.cfg
@@ -12,6 +12,8 @@ retry_files_enabled = false
 fact_caching = jsonfile
 fact_caching_connection = .ansible/cached_facts
 fact_caching_timeout = 900
+stdout_callback = skippy
+callback_whitelist = profile_tasks
 
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=900s -o GSSAPIAuthentication=no


### PR DESCRIPTION
Tune an example ansible.cfg to include
tasks profiling info and improve displaying
of skipped tasks.

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>