### PR TITLE
[WIP] Persist DNS configuration for nodes for openstack provider

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -5,12 +5,18 @@ OpenStack resources (servers, networking, volumes, security groups,
 etc.). The result is an environment ready for openshift-ansible.
 
 
-## Dependencies
+## Dependencies for localhost (ansible admin node)
 
 * [Ansible 2.3](https://pypi.python.org/pypi/ansible)
 * [shade](https://pypi.python.org/pypi/shade)
-* python-dns
+* python-dns / [dnspython](https://pypi.python.org/pypi/dnspython)
+* Become (sudo) is not required.
 
+## Dependencies for OpenStack hosted cluster nodes (servers)
+
+There are no additional dependencies for the cluster nodes. Required
+configuration steps are done by Heat given a specific user data config
+that normally should not be changed.
 
 ## What does it do
 
@@ -41,12 +47,22 @@ etc.). The result is an environment ready for openshift-ansible.
 Pay special attention to the values in the first paragraph -- these
 will depend on your OpenStack environment.
 
-The `env_id` and `openstack_dns_domain` will form the DNS domain all
+The `env_id` and `public_dns_domain` will form the cluster's DNS domain all
 your servers will be under. With the default values, this will be
-`openshift.example.com`.
+`openshift.example.com`. For workloads, the default subdomain is 'apps'.
+That sudomain can be set as well by the `openshift_app_domain` variable in
+the inventory.
 
-`openstack_nameservers` is a list of DNS servers accessible from all
-the created Nova servers. These will be serve as your DNS forwarders.
+The `public_dns_nameservers` is a list of DNS servers accessible from all
+the created Nova servers. These will be serving as your DNS forwarders for
+external FQDNs that do not belong to the cluster's DNS domain and its subdomains.
+
+The `openshift_use_dnsmasq` controls either dnsmasq is deployed or not.
+By default, dnsmasq is deployed and comes as the hosts' /etc/resolv.conf file
+first nameserver entry that points to the local host instance of the dnsmasq
+daemon that in turn proxies DNS requests to the authoritative DNS server.
+When Network Manager is enabled for provisioned cluster nodes, which is
+normally the case, you should not change the defaults and always deploy dnsmasq.
 
 `openstack_ssh_key` is a Nova keypair -- you can see your keypairs with
 `openstack keypair list`.
@@ -121,8 +137,7 @@ Once it succeeds, you can install openshift by running:
     ansible-playbook --become --user openshift --private-key ~/.ssh/openshift -i inventory/ openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
     ansible-playbook --become --user openshift --private-key ~/.ssh/openshift -i inventory/ openshift-ansible/playbooks/byo/config.yml
 
-Note, the `network_manager.yml` is only required if you're deploying OpenShift
-origin.
+Note, the `network_manager.yml` step is required in order to persist the hosts' DNS config.
 
 ## License
 

--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -1,6 +1,6 @@
 ---
-# Assign hostnames
-- hosts: cluster_hosts
+- name: Assign hostnames
+  hosts: cluster_hosts
   gather_facts: False
   become: true
   pre_tasks:
@@ -8,8 +8,8 @@
   roles:
   - role: hostnames
 
-# Subscribe DNS Host to allow for configuration below
-- hosts: dns
+- name: Subscribe DNS Host to allow for configuration below
+  hosts: dns
   gather_facts: False
   become: true
   roles:
@@ -17,15 +17,15 @@
     when: hostvars.localhost.rhsm_register
     tags: 'subscription-manager'
 
-# Determine which DNS server(s) to use for our generated records
-- hosts: localhost
+- name: Determine which DNS server(s) to use for our generated records
+  hosts: localhost:cluster_hosts:!dns
   gather_facts: False
   become: False
   roles:
   - dns-server-detect
 
-# Build the DNS Server Views and Configure DNS Server(s)
-- hosts: dns
+- name: Build the DNS Server Views and Configure DNS Server(s)
+  hosts: dns
   gather_facts: False
   become: true
   pre_tasks:
@@ -35,8 +35,8 @@
   roles:
   - role: dns-server
 
-# Build and process DNS Records
-- hosts: localhost
+- name: Build and process DNS Records
+  hosts: localhost
   gather_facts: False
   become: False
   pre_tasks:
@@ -46,18 +46,13 @@
   roles:
   - role: dns
 
-# OpenShift Pre-Requisites
-- hosts: OSEv3
+- name: OpenShift Pre-Requisites
+  hosts: OSEv3
   gather_facts: False
   become: true
+  roles:
+  - role: dnsmasq
   tasks:
-  - name: "Edit /etc/resolv.conf on masters/nodes"
-    lineinfile:
-      state: present
-      dest: /etc/resolv.conf
-      regexp: "nameserver {{ hostvars['localhost'].private_dns_server }}"
-      line: "nameserver {{ hostvars['localhost'].private_dns_server }}"
-      insertafter: search*
   - name: "Include DNS configuration to ensure proper name resolution"
     lineinfile:
       state: present

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Provide additional dnsmasq config
+  template:
+    src: openstack-dns.conf.j2
+    dest: /tmp/openstack-dnsmasq.conf
+
+- name: Define the custom dnsmasq config var for openshift-ansible
+  set_fact:
+    openshift_node_dnsmasq_additional_config_file: /tmp/openstack-dnsmasq.conf

--- a/roles/dnsmasq/templates/openstack-dns.conf.j2
+++ b/roles/dnsmasq/templates/openstack-dns.conf.j2
@@ -1,0 +1,12 @@
+strict-order
+no-resolv
+bogus-priv
+no-negcache
+cache-size=1000
+dns-forward-max=150
+max-cache-ttl=10
+max-ttl=20
+
+server=/{{ public_dns_domain }}/{{ private_dns_server }}
+# Reply NXDOMAIN to bogus domains requests like com.{{ public_dns_domain }}.{{ public_dns_domain }}
+local=/{% for d in [ public_dns_domain, full_dns_domain, openshift_master_default_subdomain ] %}{{public_dns_domain}}.{{d}}./{{d}}.{{d}}./com.{{d}}./{% endfor %}

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -61,18 +61,13 @@ outputs:
         - dns
         - name
 
-  dns_floating_ip:
-    description: Floating IP of the DNS
-    value:
-      get_attr:
-        - dns
-        - addresses
-        - str_replace:
-            template: openshift-ansible-cluster_id-net
-            params:
-              cluster_id: {{ stack_name }}
-        - 1
-        - addr
+  dns_floating_ips:
+    description: Floating IPs of the DNS
+    value: { get_attr: [ dns, floating_ip ] }
+
+  dns_private_ips:
+    description: Private IPs of the DNS
+    value: { get_attr: [ dns, private_ip ] }
 
 resources:
 
@@ -111,9 +106,9 @@ resources:
               params:
                 subnet_24_prefix: {{ subnet_prefix }}
       dns_nameservers:
-      {% for nameserver in dns_nameservers %}
+{% for nameserver in dns_nameservers %}
         - {{ nameserver }}
-      {% endfor %}
+{% endfor %}
 
   router:
     type: OS::Neutron::Router


### PR DESCRIPTION
Persist DNS configuration for nodes for openstack provider

* Add the custom dnsmasq config for openstack provider needs.
* Point the dnsmasq config to the defined private_dns_server.
* Speed up DNS queries against bogus/malformed domain names with
  NXDOMAIN reported early.
* Add the dnsmasq role to ship the custom config file for servers.
* Drop post-provision /etc/reslov.conf nameserver hacks to be
  persisted by openshift-ansible dnsmasq role via the custom config.
* Fix dns floating IPs output and add the priv IPs output as well.
* Update docs, clarify localhost vs servers requirements, add
  required Network Manager setup step.

TODO add missing docs for external_nsupdate_keys, public_dns_server.

Closes https://github.com/openshift/openshift-ansible-contrib/issues/455

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>