### PR TITLE
Use cached facts, do not become for localhost

### DIFF
--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -1,6 +1,7 @@
 ---
 # Assign hostnames
 - hosts: cluster_hosts
+  gather_facts: False
   become: true
   pre_tasks:
   - include: pre_tasks.yml
@@ -9,6 +10,7 @@
 
 # Subscribe DNS Host to allow for configuration below
 - hosts: dns
+  gather_facts: False
   become: true
   roles:
   - role: subscription-manager
@@ -17,11 +19,14 @@
 
 # Determine which DNS server(s) to use for our generated records
 - hosts: localhost
+  gather_facts: False
+  become: False
   roles:
   - dns-server-detect
 
 # Build the DNS Server Views and Configure DNS Server(s)
 - hosts: dns
+  gather_facts: False
   become: true
   pre_tasks:
   - include: pre_tasks.yml
@@ -32,6 +37,8 @@
 
 # Build and process DNS Records
 - hosts: localhost
+  gather_facts: False
+  become: False
   pre_tasks:
   - include: pre_tasks.yml
   - name: "Generate dns records"
@@ -41,6 +48,7 @@
 
 # OpenShift Pre-Requisites
 - hosts: OSEv3
+  gather_facts: False
   become: true
   tasks:
   - name: "Edit /etc/resolv.conf on masters/nodes"

--- a/playbooks/provisioning/openstack/provision-openstack.yml
+++ b/playbooks/provisioning/openstack/provision-openstack.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: localhost
   gather_facts: True
+  become: False
   pre_tasks:
   - include: pre_tasks.yml
   roles:
@@ -31,12 +32,13 @@
 - name: Refresh Server inventory
   hosts: localhost
   connection: local
+  become: False
   gather_facts: False
   tasks:
   - meta: refresh_inventory
 
 - hosts: cluster_hosts
-  gather_facts: false
+  gather_facts: True
   tasks:
   - name: Debug hostvar
     debug:

--- a/roles/openstack-stack/test/stack-create-test.yml
+++ b/roles/openstack-stack/test/stack-create-test.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: localhost
+  gather_facts: True
+  become: False
   roles:
   - role: openstack-stack
     stack_name: test-stack


### PR DESCRIPTION
Prohibit sudoing for localhost played tasks, like DNS setup.
Re-use cached facts to speed up deployment.

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>