### PR TITLE
[WIP] Make idempotent zone updates

### DIFF
--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -35,6 +35,13 @@
   roles:
   - role: dns-server
 
+- name: Refresh facts for nsupdate keys
+  hosts: dns
+  tasks:
+  - setup:
+      gather_subset: 'facter'
+      filter: nsupdate_keys
+
 - name: Build and process DNS Records
   hosts: localhost
   gather_facts: False

--- a/roles/dns-server/tasks/main.yml
+++ b/roles/dns-server/tasks/main.yml
@@ -142,6 +142,16 @@
     owner: named
     group: named
     mode: 0660
+  register: result
+  with_subelements:
+  - "{{ named_config_views }}"
+  - zone
+
+- name: Purge journal files
+  file:
+    path: /var/named/static/{{ item.0.name }}-{{ item.1.dns_domain }}.db.jnl
+    state: absent
+  when: result|changed
   with_subelements:
   - "{{ named_config_views }}"
   - zone


### PR DESCRIPTION
* Refresh nsupdates facts for dns node to fix obsoleted secrets
  used for nsupdates tasks issued against localhost (control node)
* Purge zone journal files if zone db files has been changed by
  the dns-server role applied.

Closes https://github.com/openshift/openshift-ansible-contrib/issues/494

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>