### PR TITLE
GCP: Allow for custom VPC subnet

### DIFF
--- a/reference-architecture/gce-cli/config.yaml.example
+++ b/reference-architecture/gce-cli/config.yaml.example
@@ -24,6 +24,10 @@ delete_gold_image: false
 gcloud_project: 'project-1'
 gcloud_zone: 'us-central1-a'
 
+# Custom Subnet
+# If not set will use default subnets in custom VPC
+gce_vpc_custom_subnet_cidr: 10.160.0.0/20
+
 # Public DNS domain which will be configured in Google Cloud DNS
 public_hosted_zone: 'ocp.example.com'
 # Public DNS name for the Master service

--- a/reference-architecture/gce-cli/deployment-manager/core-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/core-config.yaml.j2
@@ -8,6 +8,7 @@ resources:
     project: {{ gcloud_project }}
     region: {{ gcloud_region }}
     zone: {{ gcloud_zone }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     gold_image: {{ gold_image_family }}
     console_port: {{ console_port }}
     bastion_machine_type: {{ bastion_machine_type }}

--- a/reference-architecture/gce-cli/deployment-manager/core.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/core.jinja
@@ -21,6 +21,9 @@ resources:
         type: ONE_TO_ONE_NAT
       name: nic0
       network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+      {% if properties['gce_vpc_custom_subnet_cidr'] %}
+      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+      {% endif %}
     scheduling:
       automaticRestart: true
       onHostMaintenance: MIGRATE
@@ -61,6 +64,9 @@ resources:
         - name: external-nat
           type: ONE_TO_ONE_NAT
         network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+        {% if properties['gce_vpc_custom_subnet_cidr'] %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        {% endif %}
       scheduling:
         automaticRestart: true
         onHostMaintenance: MIGRATE
@@ -100,6 +106,9 @@ resources:
         - name: external-nat
           type: ONE_TO_ONE_NAT
         network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+        {% if properties['gce_vpc_custom_subnet_cidr'] %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        {% endif %}
       scheduling:
         automaticRestart: true
         onHostMaintenance: MIGRATE
@@ -139,6 +148,9 @@ resources:
         - name: external-nat
           type: ONE_TO_ONE_NAT
         network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+        {% if properties['gce_vpc_custom_subnet_cidr'] %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        {% endif %}
       scheduling:
         automaticRestart: true
         onHostMaintenance: MIGRATE

--- a/reference-architecture/gce-cli/deployment-manager/network-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/network-config.yaml.j2
@@ -5,4 +5,6 @@ resources:
   type: network.jinja
   properties:
     prefix: {{ prefix }}
+    region: {{ gcloud_region }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     console_port: {{ console_port }}

--- a/reference-architecture/gce-cli/deployment-manager/network.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/network.jinja
@@ -1,8 +1,21 @@
 resources:
 - name: {{ properties['prefix'] }}-network
   properties:
+  {% if properties['gce_vpc_custom_subnet_cidr'] %}
+    autoCreateSubnetworks: false
+  {% else %}
     autoCreateSubnetworks: true
+  {% endif %}
   type: compute.v1.network
+{% if properties['gce_vpc_custom_subnet_cidr'] %}
+- name: {{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+  properties:
+    ipCidrRange: {{ properties['gce_vpc_custom_subnet_cidr'] }}
+    privateIpGoogleAccess: true
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    region: {{ properties['region'] }}
+  type: compute.beta.subnetwork
+{% endif %}
 - name: {{ properties['prefix'] }}-icmp
   properties:
     allowed:

--- a/reference-architecture/gce-cli/deployment-manager/tmp-instance-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/tmp-instance-config.yaml.j2
@@ -6,4 +6,6 @@ resources:
   properties:
     prefix: {{ prefix }}
     zone: {{ gcloud_zone }}
+    region: {{ gcloud_region }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     source_family: {{ 'projects/' + gcloud_project + '/global/images/family/rhel-guest-clean' if openshift_deployment_type == 'openshift-enterprise' else 'projects/centos-cloud/global/images/family/centos-7' }}

--- a/reference-architecture/gce-cli/deployment-manager/tmp-instance.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/tmp-instance.jinja
@@ -21,6 +21,9 @@ resources:
         type: ONE_TO_ONE_NAT
       name: nic0
       network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+    {% if properties['gce_vpc_custom_subnet_cidr'] %}
+      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+    {% endif %}
     scheduling:
       automaticRestart: true
       onHostMaintenance: MIGRATE


### PR DESCRIPTION
We need our cluster hosts to be in a different CIDR range than the default so we use a custom subnet.  This allows others to do the same with a simple addition to their config.yaml