### PR TITLE
Modify sec groups for provisioned openstack servers

### DIFF
--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -152,7 +152,7 @@ resources:
             cluster_id: {{ stack_name }}
       description:
         str_replace:
-          template: Basic ssh/dns security group for cluster_id OpenShift cluster
+          template: Basic ssh/icmp security group for cluster_id OpenShift cluster
           params:
             cluster_id: {{ stack_name }}
       rules:
@@ -162,13 +162,8 @@ resources:
           port_range_max: 22
           remote_ip_prefix: {{ ssh_ingress_cidr }}
         - direction: ingress
-          protocol: tcp
-          port_range_min: 53
-          port_range_max: 53
-        - direction: ingress
-          protocol: udp
-          port_range_min: 53
-          port_range_max: 53
+          protocol: icmp
+          remote_ip_prefix: {{ ssh_ingress_cidr }}
 
 {% if openstack_flat_secgrp|bool %}
   flat-secgrp:
@@ -422,11 +417,6 @@ resources:
           params:
             cluster_id: {{ stack_name }}
       rules:
-        - direction: ingress
-          protocol: tcp
-          port_range_min: 22
-          port_range_max: 22
-          remote_ip_prefix: {{ ssh_ingress_cidr }}
         - direction: ingress
           protocol: udp
           port_range_min: 53
@@ -715,6 +705,7 @@ resources:
           subnet:      { get_resource: subnet }
           secgrp:
             - { get_resource: dns-secgrp }
+            - { get_resource: common-secgrp }
           floating_network: {{ external_network }}
           net_name:
             str_replace:


### PR DESCRIPTION
Drop ingress DNS rules from the common secgrp.
Add an ingress ICMP rule, restricted by the ssh ingress cidr,
to the common secgrp. This allows to ping servers from the
control node (ansible admin node).
Add dns servers into the common secgrp as well.

Closes https://github.com/openshift/openshift-ansible-contrib/issues/485

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>