### PR TITLE
Disable swap on nodes

### DIFF
--- a/reference-architecture/azure-ansible/node.sh
+++ b/reference-architecture/azure-ansible/node.sh
@@ -26,4 +26,10 @@ DATA_SIZE=95%VG
 EXTRA_DOCKER_STORAGE_OPTIONS="--storage-opt dm.basesize=3G"
 EOF
 
+sed -i -e 's/ResourceDisk.EnableSwap.*/ResourceDisk.EnableSwap=n/g' /etc/waagent.conf
+sed -i -e 's/ResourceDisk.SwapSizeMB.*/ResourceDisk.SwapSizeMB=0/g' /etc/waagent.conf
+swapoff -a
+# Do not restart waagent as it will make the installation fail
+#systemctl restart waagent.service
+
 touch /root/.updateok


### PR DESCRIPTION
If restarting waagent makes the installation fail, then do not restart it but leave the swap disabled in the configuration file as well as disabled with swapoff, that way, even if you restart the node, the swap will be disabled.

Tested by redeploying an Azure environment (and modifying the template to fit the github user variable), and it seems to be working:

```
[root@node01 ~]# grep -R -i "swap" /etc/waagent.conf 
# Create and use swapfile on resource disk.
ResourceDisk.EnableSwap=n
# Size of the swapfile.
ResourceDisk.SwapSizeMB=2048
[root@node01 ~]# free -m
              total        used        free      shared  buff/cache   available
Mem:          28136         381       25893           8        1860       27323
Swap:             0           0           0
```