### PR TITLE
Put back node/flat secgrp for infra nodes on openstack

### DIFF
--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -674,6 +674,12 @@ resources:
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
           secgrp:
+# TODO(bogdando) filter only required node rules into infra-secgrp
+{% if openstack_flat_secgrp|bool %}
+            - { get_resource: flat-secgrp }
+{% else %}
+            - { get_resource: node-secgrp }
+{% endif %}
             - { get_resource: infra-secgrp }
             - { get_resource: common-secgrp }
           floating_network: {{ external_network }}


### PR DESCRIPTION
Partially undo 2028883e936c8a1a0be031a19d531d0804a32b68
to unblock end-to-end deployments

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>