### PR TITLE
Adds aws credentials cfn stack lookup

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/roles/cfn-outputs/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/cfn-outputs/tasks/main.yaml
@@ -3,6 +3,8 @@
   cloudformation_facts:
     stack_name: "{{ stack_name }}"
     region: "{{ region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
   register: stack
 
 - name: Set s3 facts


### PR DESCRIPTION
Adds (what I believe is) missing aws credentials as an input to cfn-outputs task.

without this I have not been able to use the playbooks that generate the ansible inventory or validates the openshift deployment.