### PR TITLE
Enable dnsmasq or it fails resolving k8s svc

### DIFF
--- a/reference-architecture/azure-ansible/bastion.sh
+++ b/reference-architecture/azure-ansible/bastion.sh
@@ -253,7 +253,7 @@ openshift_master_default_subdomain=${WILDCARDNIP}
 #openshift_master_default_subdomain=${WILDCARDZONE}.${FULLDOMAIN}
 # osm_default_subdomain=${WILDCARDZONE}.${FULLDOMAIN}
 osm_default_subdomain=${WILDCARDNIP}
-openshift_use_dnsmasq=false
+openshift_use_dnsmasq=true
 openshift_public_hostname=${RESOURCEGROUP}.${FULLDOMAIN}
 
 openshift_master_cluster_method=native
@@ -470,4 +470,3 @@ chmod 755 /home/${AUSERNAME}/openshift-install.sh
 echo "${RESOURCEGROUP} Bastion Host is starting OpenShift Install" | mail -s "${RESOURCEGROUP} Bastion OpenShift Install Starting" ${RHNUSERNAME} || true
 /home/${AUSERNAME}/openshift-install.sh &> /home/${AUSERNAME}/openshift-install.out &
 exit 0
-

--- a/reference-architecture/azure-ansible/master.sh
+++ b/reference-architecture/azure-ansible/master.sh
@@ -13,12 +13,7 @@ SSHPUBLICDATA=${10}
 SSHPUBLICDATA2=${11}
 SSHPUBLICDATA3=${12}
 
-domain=$(grep search /etc/resolv.conf | awk '{print $2}')
-
 ps -ef | grep master.sh > cmdline.out
-
-systemctl enable dnsmasq.service
-systemctl start dnsmasq.service
 
 mkdir -p /home/$USERNAME/.ssh
 echo $SSHPUBLICDATA $SSHPUBLICDATA2 $SSHPUBLICDATA3 >  /home/$USERNAME/.ssh/id_rsa.pub

--- a/reference-architecture/azure-ansible/node.sh
+++ b/reference-architecture/azure-ansible/node.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-domain=$(grep search /etc/resolv.conf | awk '{print $2}')
-
-systemctl enable dnsmasq.service
-systemctl start dnsmasq.service
-
 #yum -y update
 yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion
 


### PR DESCRIPTION
Trying to deploy metrics, the hawkular-metrics pod failed to deploy:

```
[edu@bastion ~]$ oc logs -f hawkular-metrics-05mmk
2017-06-29 09:28:50 Starting Hawkular Metrics
Error: the service account for Hawkular Metrics does not have permission to view resources in this namespace. View permissions are required for Hawkular Metrics to function properly.
Usually this can be resolved by running: oc adm policy add-role-to-user view system:serviceaccount:openshift-infra:hawkular -n openshift-infra
```

What it was really happening was DNS is broken and it cannot access the k8s svc as it cannot find the hostname (I've tried all the k8s svc combinations, none worked).

I think other OCP components (like router/registry) uses the service IP instead the hostname so they were running properly...