### PR TITLE
Copies inventory to path specified in RA aws docs

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/roles/inventory-file-creation/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/inventory-file-creation/tasks/main.yaml
@@ -72,5 +72,5 @@
 - name: copy generated inventory file to users $HOME directory
   template:
     src: ../static-inventory
-    dest: /home/ec2-user/inventory
+    dest: ~/inventory
     remote_src: false

--- a/reference-architecture/aws-ansible/playbooks/roles/inventory-file-creation/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/inventory-file-creation/tasks/main.yaml
@@ -68,3 +68,9 @@
   when:
   - groups.tag_openshift_role_storage is defined and hostvars[item]['ec2_tag_KubernetesCluster'] == stack_name
   ignore_errors: true
+  
+- name: copy generated inventory file to users $HOME directory
+  template:
+    src: ../static-inventory
+    dest: /home/ec2-user/inventory
+    remote_src: false


### PR DESCRIPTION
https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/deploying_openshift_container_platform_3.5_on_amazon_web_services/#running_the_uninstall_playbook 

uninstall playbook uses inventory file at /home/user/inventory. but im going on a limb here and setting it to ec2-user as thats the user aws creates by default.