### PR TITLE
Use wait_for_connection for the Heat nodes

### DIFF
--- a/playbooks/provisioning/openstack/provision-openstack.yml
+++ b/playbooks/provisioning/openstack/provision-openstack.yml
@@ -43,7 +43,7 @@
   become: False
   gather_facts: False
   tasks:
-    - wait_for_connection:
+  - wait_for_connection:
 
 - hosts: cluster_hosts
   gather_facts: True

--- a/playbooks/provisioning/openstack/provision-openstack.yml
+++ b/playbooks/provisioning/openstack/provision-openstack.yml
@@ -39,14 +39,18 @@
   - meta: refresh_inventory
 
 - hosts: cluster_hosts
+  name: Wait for the the nodes to come up
+  become: False
+  gather_facts: False
+  tasks:
+    - wait_for_connection:
+
+- hosts: cluster_hosts
   gather_facts: True
   tasks:
   - name: Debug hostvar
     debug:
       msg: "{{ hostvars[inventory_hostname] }}"
       verbosity: 2
-  - name: waiting for server to come back
-    local_action: wait_for host={{ hostvars[inventory_hostname]['ansible_ssh_host'] }} port=22 delay=30 timeout=300
-    become: false
 
 - include: post-provision-openstack.yml


### PR DESCRIPTION
The `wait_for_connection` module is more reliable as it uses Ansible's `ping`
to verify the nodes are really accessible. Using `wait_for` and checking that
port 22 is open runs into the possibility of SSH being up but the public keys
or users not being set up yet (as that's done with cloud-init).

In addition, we were gathering facts before running the wait_for task which
rendered it useless.