### PR TITLE
GCP: Allow for custom VPC subnet II

### DIFF
--- a/reference-architecture/gce-cli/config.yaml.example
+++ b/reference-architecture/gce-cli/config.yaml.example
@@ -86,4 +86,5 @@ node_docker_disk_size: 25
 node_openshift_disk_size: 50
 
 # Custom VPC Subnet, example value: '10.160.0.0/20'
+# Default value is empty, when random subnet in form of 10.x.0.0/20 will be used
 gce_vpc_custom_subnet_cidr: ''

--- a/reference-architecture/gce-cli/config.yaml.example
+++ b/reference-architecture/gce-cli/config.yaml.example
@@ -24,10 +24,6 @@ delete_gold_image: false
 gcloud_project: 'project-1'
 gcloud_zone: 'us-central1-a'
 
-# Custom Subnet
-# If not set will use default subnets in custom VPC
-gce_vpc_custom_subnet_cidr: 10.160.0.0/20
-
 # Public DNS domain which will be configured in Google Cloud DNS
 public_hosted_zone: 'ocp.example.com'
 # Public DNS name for the Master service
@@ -78,7 +74,7 @@ openshift_master_identity_providers:
 
 
 ###
-### Default values ###
+### Supplemental options ###
 ###
 
 
@@ -88,3 +84,6 @@ master_boot_disk_size: 35
 node_boot_disk_size: 25
 node_docker_disk_size: 25
 node_openshift_disk_size: 50
+
+# Custom VPC Subnet, example value: '10.160.0.0/20'
+gce_vpc_custom_subnet_cidr: ''

--- a/reference-architecture/gce-cli/config.yaml.example
+++ b/reference-architecture/gce-cli/config.yaml.example
@@ -24,6 +24,10 @@ delete_gold_image: false
 gcloud_project: 'project-1'
 gcloud_zone: 'us-central1-a'
 
+# Custom Subnet
+# If not set will use default subnets in custom VPC
+gce_vpc_custom_subnet_cidr: 10.160.0.0/20
+
 # Public DNS domain which will be configured in Google Cloud DNS
 public_hosted_zone: 'ocp.example.com'
 # Public DNS name for the Master service

--- a/reference-architecture/gce-cli/deployment-manager/core-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/core-config.yaml.j2
@@ -8,6 +8,7 @@ resources:
     project: {{ gcloud_project }}
     region: {{ gcloud_region }}
     zone: {{ gcloud_zone }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     gold_image: {{ gold_image_family }}
     console_port: {{ console_port }}
     bastion_machine_type: {{ bastion_machine_type }}

--- a/reference-architecture/gce-cli/deployment-manager/core-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/core-config.yaml.j2
@@ -8,7 +8,6 @@ resources:
     project: {{ gcloud_project }}
     region: {{ gcloud_region }}
     zone: {{ gcloud_zone }}
-    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     gold_image: {{ gold_image_family }}
     console_port: {{ console_port }}
     bastion_machine_type: {{ bastion_machine_type }}
@@ -21,3 +20,4 @@ resources:
     infra_node_instance_group_size: {{ infra_node_instance_group_size }}
     node_instance_group_size: {{ node_instance_group_size }}
     gcs_registry_bucket: {{ gcs_registry_bucket }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr }}

--- a/reference-architecture/gce-cli/deployment-manager/core.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/core.jinja
@@ -21,6 +21,9 @@ resources:
         type: ONE_TO_ONE_NAT
       name: nic0
       network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+      {% if properties['gce_vpc_custom_subnet_cidr'] %}
+      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+      {% endif %}
     scheduling:
       automaticRestart: true
       onHostMaintenance: MIGRATE
@@ -61,6 +64,9 @@ resources:
         - name: external-nat
           type: ONE_TO_ONE_NAT
         network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+        {% if properties['gce_vpc_custom_subnet_cidr'] %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        {% endif %}
       scheduling:
         automaticRestart: true
         onHostMaintenance: MIGRATE
@@ -100,6 +106,9 @@ resources:
         - name: external-nat
           type: ONE_TO_ONE_NAT
         network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+        {% if properties['gce_vpc_custom_subnet_cidr'] %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        {% endif %}
       scheduling:
         automaticRestart: true
         onHostMaintenance: MIGRATE
@@ -139,6 +148,9 @@ resources:
         - name: external-nat
           type: ONE_TO_ONE_NAT
         network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+        {% if properties['gce_vpc_custom_subnet_cidr'] %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        {% endif %}
       scheduling:
         automaticRestart: true
         onHostMaintenance: MIGRATE

--- a/reference-architecture/gce-cli/deployment-manager/network-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/network-config.yaml.j2
@@ -5,4 +5,6 @@ resources:
   type: network.jinja
   properties:
     prefix: {{ prefix }}
+    region: {{ gcloud_region }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     console_port: {{ console_port }}

--- a/reference-architecture/gce-cli/deployment-manager/network-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/network-config.yaml.j2
@@ -6,5 +6,5 @@ resources:
   properties:
     prefix: {{ prefix }}
     region: {{ gcloud_region }}
-    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     console_port: {{ console_port }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr }}

--- a/reference-architecture/gce-cli/deployment-manager/network.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/network.jinja
@@ -1,8 +1,21 @@
 resources:
 - name: {{ properties['prefix'] }}-network
   properties:
+  {% if properties['gce_vpc_custom_subnet_cidr'] %}
+    autoCreateSubnetworks: false
+  {% else %}
     autoCreateSubnetworks: true
+  {% endif %}
   type: compute.v1.network
+{% if properties['gce_vpc_custom_subnet_cidr'] %}
+- name: {{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+  properties:
+    ipCidrRange: {{ properties['gce_vpc_custom_subnet_cidr'] }}
+    privateIpGoogleAccess: true
+    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    region: {{ properties['region'] }}
+  type: compute.beta.subnetwork
+{% endif %}
 - name: {{ properties['prefix'] }}-icmp
   properties:
     allowed:

--- a/reference-architecture/gce-cli/deployment-manager/network.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/network.jinja
@@ -14,7 +14,7 @@ resources:
     privateIpGoogleAccess: true
     network: $(ref.{{ properties['prefix'] }}-network.selfLink)
     region: {{ properties['region'] }}
-  type: compute.beta.subnetwork
+  type: compute.v1.subnetwork
 {% endif %}
 - name: {{ properties['prefix'] }}-icmp
   properties:

--- a/reference-architecture/gce-cli/deployment-manager/tmp-instance-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/tmp-instance-config.yaml.j2
@@ -6,4 +6,6 @@ resources:
   properties:
     prefix: {{ prefix }}
     zone: {{ gcloud_zone }}
+    region: {{ gcloud_region }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
     source_family: {{ 'projects/' + gcloud_project + '/global/images/family/rhel-guest-clean' if openshift_deployment_type == 'openshift-enterprise' else 'projects/centos-cloud/global/images/family/centos-7' }}

--- a/reference-architecture/gce-cli/deployment-manager/tmp-instance-config.yaml.j2
+++ b/reference-architecture/gce-cli/deployment-manager/tmp-instance-config.yaml.j2
@@ -7,5 +7,5 @@ resources:
     prefix: {{ prefix }}
     zone: {{ gcloud_zone }}
     region: {{ gcloud_region }}
-    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr|default('') }}
+    gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr }}
     source_family: {{ 'projects/' + gcloud_project + '/global/images/family/rhel-guest-clean' if openshift_deployment_type == 'openshift-enterprise' else 'projects/centos-cloud/global/images/family/centos-7' }}

--- a/reference-architecture/gce-cli/deployment-manager/tmp-instance.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/tmp-instance.jinja
@@ -21,6 +21,9 @@ resources:
         type: ONE_TO_ONE_NAT
       name: nic0
       network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
+    {% if properties['gce_vpc_custom_subnet_cidr'] %}
+      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+    {% endif %}
     scheduling:
       automaticRestart: true
       onHostMaintenance: MIGRATE

--- a/reference-architecture/gce-cli/deployment-manager/tmp-instance.jinja
+++ b/reference-architecture/gce-cli/deployment-manager/tmp-instance.jinja
@@ -21,9 +21,9 @@ resources:
         type: ONE_TO_ONE_NAT
       name: nic0
       network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
-    {% if properties['gce_vpc_custom_subnet_cidr'] %}
+      {% if properties['gce_vpc_custom_subnet_cidr'] %}
       subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
-    {% endif %}
+      {% endif %}
     scheduling:
       automaticRestart: true
       onHostMaintenance: MIGRATE


### PR DESCRIPTION
#### What does this PR do?
This is slightly modified PR #500 . It enables you to specify custom VPC subnet when creating network in GCP.

#### How should this be manually tested?
In config file configure custom subnet, e.g. `gce_vpc_custom_subnet_cidr: '10.160.0.0/20'`, then verify that the subnet was created and that instances are connected to it:
```
$ gcloud compute networks subnets list
NAME                           REGION        NETWORK            RANGE
ocp-peter-europe-west1-subnet  europe-west1  ocp-peter-network  10.160.0.0/20

$ gcloud compute instances describe ocp-peter-bastion --format='value(networkInterfaces.subnetwork)'
https://www.googleapis.com/compute/v1/projects/ose-refarch/regions/europe-west1/subnetworks/ocp-peter-europe-west1-subnet
```

#### Is there a relevant Issue open for this?
Just the PR #500 

#### Who would you like to review this?
cc: @bdurrow @e-minguez  PTAL
