### PR TITLE
Make enabling/disabling repos idempotent

### DIFF
--- a/roles/rhsm-repos/defaults/main.yaml
+++ b/roles/rhsm-repos/defaults/main.yaml
@@ -1,2 +1,6 @@
 ---
-openshift_required_repos: ['rhel-7-server-rpms', 'rhel-7-server-extras-rpms', 'rhel-7-server-ose-3.5-rpms', 'rhel-7-fast-datapath-rpms']
+openshift_required_repos:
+  - rhel-7-server-rpms
+  - rhel-7-server-extras-rpms
+  - rhel-7-server-ose-3.5-rpms
+  - rhel-7-fast-datapath-rpms

--- a/roles/rhsm-repos/tasks/main.yaml
+++ b/roles/rhsm-repos/tasks/main.yaml
@@ -1,11 +1,36 @@
 ---
 - block:
+    - name: get enabled repos
+      shell: >
+        subscription-manager repos --list-enabled |
+        grep "Repo ID" |
+        awk '{print $NF}'
+      register: result
+      changed_when: false
+
+    - set_fact:
+        current_repos: []
+      when: result.stdout == ""
+
+    - set_fact:
+        current_repos: "{{ result.stdout.split('\n') }}"
+      when: result.stdout != ""
+
+    - set_fact:
+        repos_to_disable: "{{ current_repos | difference(openshift_required_repos) }}"
+        repos_to_enable: "{{ openshift_required_repos | difference(current_repos) }}"
+
     - name: disable unneeded repos
-      command: subscription-manager repos --disable='*'
+      command: >
+        subscription-manager repos
+        --disable={{ repos_to_disable | join(" --disable=") }}
+      when: repos_to_disable | length > 0
 
     - name: ensure proper repos are assigned
-      command: subscription-manager repos --enable={{ item }}
-      with_items: "{{ openshift_required_repos }}"
+      command: >
+        subscription-manager repos
+        --enable={{ repos_to_enable | join(" --enable=") }}
+      when: repos_to_enable | length > 0
 
     - name: check to see if rhui exists
       stat:


### PR DESCRIPTION
#### What does this PR do?
When enabling RHEL repos, Ansible disables all repos and then enables only those that are listed in `openshift_required_repos`. It does this every time the playbook is executed. This patch only disables those repos not listed in ` openshift_required_repos`, and it only enables those repos than aren't already enabled.

In addition to making this play idempotent, it also shortens run times by not having to run `subscription-manager` every time the play is ran.

#### How should this be manually tested?
`vagrant provision admin1`

The first time this is executed, extra repos will be disabled, and missing repos will be enabled. The second time this is executed, no changes will be made.

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @tomassedovic @bogdando @cooktheryan PTAL
