### PR TITLE
Azure logging metrics and logging deployment in post installation step

### DIFF
--- a/reference-architecture/azure-ansible/ansibledeployocp/README.md
+++ b/reference-architecture/azure-ansible/ansibledeployocp/README.md
@@ -101,7 +101,9 @@ Optional (default values are set in [playbooks/roles/azure-deploy/default/main.y
 * infranodesize: Infrastructure nodes VM size
 * nodevmsize: Application nodes VM size
 * location: westus by default
-* metrics: true to enable cluster metrics, false to not enable (note, do not quote as those variables are boolean values, not strings)
+* metrics: true to enable cluster metrics, false to not enable (note, do not quote as those variables are boolean values, not strings), true by default
+* logging: true to enable cluster logging, false to not enable (note, do not quote as those variables are boolean values, not strings), true by default
+* opslogging: true to enable ops cluster logging, false to not enable (note, do not quote as those variables are boolean values, not strings), false by default
 
 ## Running the deploy
 

--- a/reference-architecture/azure-ansible/ansibledeployocp/playbooks/roles/azure-deploy/defaults/main.yaml
+++ b/reference-architecture/azure-ansible/ansibledeployocp/playbooks/roles/azure-deploy/defaults/main.yaml
@@ -7,3 +7,5 @@ infranodesize: "Standard_DS3_v2"
 nodevmsize: "Standard_DS12_v2"
 location: "westus"
 metrics: true
+logging: true
+opslogging: false

--- a/reference-architecture/azure-ansible/ansibledeployocp/playbooks/roles/azure-deploy/tasks/main.yaml
+++ b/reference-architecture/azure-ansible/ansibledeployocp/playbooks/roles/azure-deploy/tasks/main.yaml
@@ -40,6 +40,10 @@
         value: "{{ rhsmusernamepasswordoractivationkey }}"
       metrics:
         value: "{{ metrics }}"
+      logging:
+        value: "{{ logging }}"
+      opslogging:
+        value: "{{ opslogging }}"
 
   register: azuredeploy
 

--- a/reference-architecture/azure-ansible/ansibledeployocp/vars.yaml.example
+++ b/reference-architecture/azure-ansible/ansibledeployocp/vars.yaml.example
@@ -56,3 +56,7 @@ wildcardzone: "myapps"
 # location: "westus"
 # Deploy metrics
 # metrics: true
+# Deploy agregated logging
+# logging: true
+# Deploy agregated logging for ops
+# opslogging: true

--- a/reference-architecture/azure-ansible/azuredeploy.json
+++ b/reference-architecture/azure-ansible/azuredeploy.json
@@ -512,12 +512,11 @@
     "infraLbHttpProbeId" : "[concat(variables('infraLbId'),'/probes/httpProbe')]",
     "infraLbHttpsProbeId" : "[concat(variables('infraLbId'),'/probes/httpsProbe')]",
     "infraLbCockpitProbeId" : "[concat(variables('infraLbId'),'/probes/cockpitProbe')]",
-    "persistentVolume1Type" : "Standard_LRS",
     "StorageAccountPersistentVolume" : "[concat('sapv', resourceGroup().name)]",
     "StorageAccountLoggingMetricsVolumes" : "[concat('sapvlm', resourceGroup().name)]",
     "registryStorageName" : "[concat('sareg', resourceGroup().name)]",
     "subscriptionId" : "[subscription().subscriptionId]",
-    "persistentVolume2Type" : "Standard_LRS",
+    "StorageAccountLoggingMetricsVolumesVolumeType" : "Premium_LRS",
     "apiVersion" : "2015-06-15",
     "apiVersionCompute" : "2015-06-15",
     "apiVersionNetwork" : "2016-03-30",
@@ -1152,7 +1151,7 @@
         "displayName" : "StorageAccountLoggingMetricsVolumes"
       },
       "properties" : {
-        "accountType" : "[variables('persistentVolume2Type')]"
+        "accountType" : "[variables('StorageAccountLoggingMetricsVolumesVolumeType')]"
       }
     },
     {

--- a/reference-architecture/azure-ansible/azuredeploy.json
+++ b/reference-architecture/azure-ansible/azuredeploy.json
@@ -297,8 +297,8 @@
     }
   },
   "variables" : {
-    "gituser" : "e-minguez",
-    "branch" : "azure_logging",
+    "gituser" : "openshift",
+    "branch" : "master",
     "baseTemplateUrl" : "[concat('https://raw.githubusercontent.com/',variables('gituser'),'/openshift-ansible-contrib/',variables('branch'),'/reference-architecture/azure-ansible/')]",
     "baseVMachineTemplateUriInfranode" : "[concat(variables('baseTemplateUrl'), 'infranode.json')]",
     "baseVMachineTemplateUriNode" : "[concat(variables('baseTemplateUrl'), 'node.json')]",

--- a/reference-architecture/azure-ansible/azuredeploy.json
+++ b/reference-architecture/azure-ansible/azuredeploy.json
@@ -280,11 +280,25 @@
       "metadata" :{
         "description" : "Enable OCP metrics"
       }
+    },
+    "logging" : {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata" :{
+        "description" : "Enable OCP aggregated logging"
+      }
+    },
+    "opslogging" : {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata" :{
+        "description" : "Enable OCP aggregated logging for ops"
+      }
     }
   },
   "variables" : {
-    "gituser" : "openshift",
-    "branch" : "master",
+    "gituser" : "e-minguez",
+    "branch" : "azure_logging",
     "baseTemplateUrl" : "[concat('https://raw.githubusercontent.com/',variables('gituser'),'/openshift-ansible-contrib/',variables('branch'),'/reference-architecture/azure-ansible/')]",
     "baseVMachineTemplateUriInfranode" : "[concat(variables('baseTemplateUrl'), 'infranode.json')]",
     "baseVMachineTemplateUriNode" : "[concat(variables('baseTemplateUrl'), 'node.json')]",
@@ -499,8 +513,8 @@
     "infraLbHttpsProbeId" : "[concat(variables('infraLbId'),'/probes/httpsProbe')]",
     "infraLbCockpitProbeId" : "[concat(variables('infraLbId'),'/probes/cockpitProbe')]",
     "persistentVolume1Type" : "Standard_LRS",
-    "newStorageAccountPersistentVolume1" : "[concat('sapv1', resourceGroup().name)]",
-    "newStorageAccountPersistentVolume2" : "[concat('sapv2', resourceGroup().name)]",
+    "StorageAccountPersistentVolume" : "[concat('sapv', resourceGroup().name)]",
+    "StorageAccountLoggingMetricsVolumes" : "[concat('sapvlm', resourceGroup().name)]",
     "registryStorageName" : "[concat('sareg', resourceGroup().name)]",
     "subscriptionId" : "[subscription().subscriptionId]",
     "persistentVolume2Type" : "Standard_LRS",
@@ -726,6 +740,12 @@
           },
           "metrics" : {
             "value" : "[parameters('metrics')]"
+          },
+          "logging" : {
+            "value" : "[parameters('logging')]"
+          },
+          "opslogging" : {
+            "value" : "[parameters('opslogging')]"
           }
         }
       }
@@ -1113,11 +1133,11 @@
     },
     {
       "type" : "Microsoft.Storage/storageAccounts",
-      "name" : "[variables('newStorageAccountPersistentVolume1')]",
+      "name" : "[variables('StorageAccountPersistentVolume')]",
       "apiVersion" : "[variables('apiVersion')]",
       "location" : "[variables('location')]",
       "tags" : {
-        "displayName" : "PersistentVolume1StorageAccount"
+        "displayName" : "StorageAccountPersistentVolume"
       },
       "properties" : {
         "accountType" : "[variables('vmSizesMap')[parameters('nodeVmSize')].storageAccountType]"
@@ -1125,11 +1145,11 @@
     },
     {
       "type" : "Microsoft.Storage/storageAccounts",
-      "name" : "[variables('newStorageAccountPersistentVolume2')]",
+      "name" : "[variables('StorageAccountLoggingMetricsVolumes')]",
       "apiVersion" : "[variables('apiVersion')]",
       "location" : "[variables('location')]",
       "tags" : {
-        "displayName" : "PersistentVolume2StorageAccount"
+        "displayName" : "StorageAccountLoggingMetricsVolumes"
       },
       "properties" : {
         "accountType" : "[variables('persistentVolume2Type')]"

--- a/reference-architecture/azure-ansible/bastion.json
+++ b/reference-architecture/azure-ansible/bastion.json
@@ -88,6 +88,12 @@
     },
     "metrics" : {
       "type" : "bool"
+    },
+    "logging" : {
+      "type" : "bool"
+    },
+    "opslogging" : {
+      "type" : "bool"
     }
   },
   "variables" : {
@@ -212,7 +218,7 @@
           ]
         },
         "protectedSettings" : {
-          "commandToExecute" : "[ concat('bash bastion.sh ', resourceGroup().name, ' ', parameters('wildcardZone'), ' ',  parameters('adminUsername'), ' ', parameters('adminPassword'), ' ', reference(concat(parameters('vmName'), 'pip')).dnsSettings.fqdn, ' ', padLeft(parameters('numberOfNodes'), 2, '0'), ' ', parameters('routerExtIP'),' ', parameters('RHNUserName'), ' ', parameters('RHNPassword'),' ', parameters('SubscriptionPoolId'), ' ',  variables('sQuote'),  parameters('sshPrivateData'), variables('sQuote'),  ' ', variables('sQuote'), parameters('sshKeyData'), variables('sQuote'),' ',parameters('registrystoragename'),' ',parameters('registrykey'),' ',parameters('location'),' ',parameters('subscriptionid'),' ',parameters('tenantid'),' ',parameters('aadclientid'),' ',parameters('aadclientsecret'),' ',parameters('rhsmmode'),' ',parameters('metrics'))]"
+          "commandToExecute" : "[ concat('bash bastion.sh ', resourceGroup().name, ' ', parameters('wildcardZone'), ' ',  parameters('adminUsername'), ' ', parameters('adminPassword'), ' ', reference(concat(parameters('vmName'), 'pip')).dnsSettings.fqdn, ' ', padLeft(parameters('numberOfNodes'), 2, '0'), ' ', parameters('routerExtIP'),' ', parameters('RHNUserName'), ' ', parameters('RHNPassword'),' ', parameters('SubscriptionPoolId'), ' ',  variables('sQuote'),  parameters('sshPrivateData'), variables('sQuote'),  ' ', variables('sQuote'), parameters('sshKeyData'), variables('sQuote'),' ',parameters('registrystoragename'),' ',parameters('registrykey'),' ',parameters('location'),' ',parameters('subscriptionid'),' ',parameters('tenantid'),' ',parameters('aadclientid'),' ',parameters('aadclientsecret'),' ',parameters('rhsmmode'),' ',parameters('metrics'),' ',parameters('logging'),' ',parameters('opslogging'))]"
         }
       }
     },

--- a/reference-architecture/azure-ansible/bastion.sh
+++ b/reference-architecture/azure-ansible/bastion.sh
@@ -25,10 +25,18 @@ export AADCLIENTID=${array[19]}
 export AADCLIENTSECRET=${array[20]}
 export RHSMMODE=${array[21]}
 export METRICS=${array[22]}
+export LOGGING=${array[23]}
+export OPSLOGGING=${array[24]}
 export FULLDOMAIN=${THEHOSTNAME#*.*}
 export WILDCARDFQDN=${WILDCARDZONE}.${FULLDOMAIN}
 export WILDCARDIP=`dig +short ${WILDCARDFQDN}`
 export WILDCARDNIP=${WILDCARDIP}.nip.io
+export LOGGING_ES_INSTANCES="3"
+export OPSLOGGING_ES_INSTANCES="3"
+export METRICS_INSTANCES="1"
+export LOGGING_ES_SIZE="10"
+export OPSLOGGING_ES_SIZE="10"
+export METRICS_CASSANDRASIZE="10"
 echo "Show wildcard info"
 echo $WILDCARDFQDN
 echo $WILDCARDIP
@@ -151,7 +159,7 @@ subscription-manager attach --pool=$RHNPOOLID
 subscription-manager repos --disable="*"
 subscription-manager repos --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-fast-datapath-rpms"
 subscription-manager repos --enable="rhel-7-server-ose-3.5-rpms"
-yum -y install atomic-openshift-utils git net-tools bind-utils iptables-services bridge-utils bash-completion httpd-tools nodejs
+yum -y install atomic-openshift-utils git net-tools bind-utils iptables-services bridge-utils bash-completion httpd-tools nodejs qemu-img
 touch /root/.updateok
 
 # Create azure.conf file
@@ -213,11 +221,13 @@ cat <<EOF > /etc/ansible/hosts
 masters
 nodes
 etcd
+new_nodes
+new_masters
 
 [OSEv3:vars]
 osm_controller_args={'cloud-provider': ['azure'], 'cloud-config': ['/etc/azure/azure.conf']}
 osm_api_server_args={'cloud-provider': ['azure'], 'cloud-config': ['/etc/azure/azure.conf']}
-openshift_node_kubelet_args={'cloud-provider': ['azure'], 'cloud-config': ['/etc/azure/azure.conf']}
+openshift_node_kubelet_args={'cloud-provider': ['azure'], 'cloud-config': ['/etc/azure/azure.conf'], 'enable-controller-attach-detach': ['true']}
 debug_level=2
 console_port=8443
 docker_udev_workaround=True
@@ -262,11 +272,34 @@ openshift_master_cluster_method=native
 openshift_master_cluster_hostname=${RESOURCEGROUP}.${FULLDOMAIN}
 openshift_master_cluster_public_hostname=${RESOURCEGROUP}.${FULLDOMAIN}
 
-openshift_hosted_metrics_deploy=${METRICS}
-openshift_metrics_cassandra_storage_type=dynamic
+# Do not install metrics but post install
+openshift_metrics_install_metrics=false
+openshift_metrics_cassandra_storage_type=pv
+openshift_metrics_cassandra_pvc_size="${METRICS_CASSANDRASIZE}G"
+openshift_metrics_cassandra_replicas="${METRICS_INSTANCES}"
 openshift_metrics_hawkular_nodeselector={"role":"infra"}
 openshift_metrics_cassandra_nodeselector={"role":"infra"}
 openshift_metrics_heapster_nodeselector={"role":"infra"}
+
+# Do not install logging but post install
+openshift_logging_install_logging=false
+openshift_logging_es_pv_selector={"usage":"elasticsearch"}
+openshift_logging_es_pvc_dynamic="false"
+openshift_logging_es_pvc_size="${LOGGING_ES_SIZE}G"
+openshift_logging_es_cluster_size=${LOGGING_ES_INSTANCES}
+openshift_logging_fluentd_nodeselector={"logging":"true"}
+openshift_logging_es_nodeselector={"role":"infra"}
+openshift_logging_kibana_nodeselector={"role":"infra"}
+openshift_logging_curator_nodeselector={"role":"infra"}
+
+openshift_logging_use_ops=false
+openshift_logging_es_ops_pv_selector={"usage":"opselasticsearch"}
+openshift_logging_es_ops_pvc_dynamic="false"
+openshift_logging_es_ops_pvc_size="${OPSLOGGING_ES_SIZE}G"
+openshift_logging_es_ops_cluster_size=${OPSLOGGING_ES_INSTANCES}
+openshift_logging_es_ops_nodeselector={"role":"infra"}
+openshift_logging_kibana_ops_nodeselector={"role":"infra"}
+openshift_logging_curator_ops_nodeselector={"role":"infra"}
 
 [masters]
 master1 openshift_hostname=master1 openshift_node_labels="{'role': 'master'}"
@@ -278,21 +311,24 @@ master1
 master2
 master3
 
+[new_nodes]
+[new_masters]
+
 [nodes]
-master1 openshift_hostname=master1 openshift_node_labels="{'role':'master','zone':'default'}" openshift_schedulable=false
-master2 openshift_hostname=master2 openshift_node_labels="{'role':'master','zone':'default'}" openshift_schedulable=false
-master3 openshift_hostname=master3 openshift_node_labels="{'role':'master','zone':'default'}" openshift_schedulable=false
-infranode1 openshift_hostname=infranode1 openshift_node_labels="{'role': 'infra', 'zone': 'default'}"
-infranode2 openshift_hostname=infranode2 openshift_node_labels="{'role': 'infra', 'zone': 'default'}"
-infranode3 openshift_hostname=infranode3 openshift_node_labels="{'role': 'infra', 'zone': 'default'}"
+master1 openshift_hostname=master1 openshift_node_labels="{'role':'master','zone':'default','logging':'true'}" openshift_schedulable=false
+master2 openshift_hostname=master2 openshift_node_labels="{'role':'master','zone':'default','logging':'true'}" openshift_schedulable=false
+master3 openshift_hostname=master3 openshift_node_labels="{'role':'master','zone':'default','logging':'true'}" openshift_schedulable=false
+infranode1 openshift_hostname=infranode1 openshift_node_labels="{'role': 'infra', 'zone': 'default','logging':'true'}"
+infranode2 openshift_hostname=infranode2 openshift_node_labels="{'role': 'infra', 'zone': 'default','logging':'true'}"
+infranode3 openshift_hostname=infranode3 openshift_node_labels="{'role': 'infra', 'zone': 'default','logging':'true'}"
 EOF
 
 # Loop to add Nodes
-
 for (( c=01; c<$NODECOUNT+1; c++ ))
 do
   pnum=$(printf "%02d" $c)
-  echo "node${pnum} openshift_node_labels=\"{'role': 'app', 'zone': 'default'}\" openshift_hostname=node${pnum}" >> /etc/ansible/hosts
+  echo "node${pnum} openshift_hostname=node${pnum} \
+openshift_node_labels=\"{'role':'app','zone':'default','logging':'true'}\"" >> /etc/ansible/hosts
 done
 
 
@@ -382,7 +418,7 @@ EOF
 
 npm install -g azure-cli
 azure telemetry --disable
-cat <<'EOF' > /home/${AUSERNAME}/createvhdcontainer.sh
+cat <<'EOF' > /home/${AUSERNAME}/create_azure_storage_container.sh
 # $1 is the storage account to create container
 mkdir -p ~/.azuresettings/$1
 export TENANT=$(< ~/.azuresettings/tenant_id)
@@ -394,20 +430,22 @@ azure storage account connectionstring show ${1} --resource-group ${RESOURCEGROU
 sed -n '/connectionstring:/{p}' < ~/.azuresettings/${1}/connection.out > ~/.azuresettings/${1}/dataline.out
 export DATALINE=$(< ~/.azuresettings/${1}/dataline.out)
 export AZURE_STORAGE_CONNECTION_STRING=${DATALINE:27}
-azure storage container create vhds > ~/.azuresettings/${1}/container.dat
+azure storage container create ${2} > ~/.azuresettings/${1}/container.dat
 EOF
-chmod +x /home/${AUSERNAME}/createvhdcontainer.sh
+chmod +x /home/${AUSERNAME}/create_azure_storage_container.sh
 
 cat <<EOF > /home/${AUSERNAME}/scgeneric.yml
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
-  name: generic
+  name: "generic"
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
+    volume.beta.kubernetes.io/storage-class: "generic"
+    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/azure-disk
 provisioner: kubernetes.io/azure-disk
 parameters:
-  storageAccount: sapv1${RESOURCEGROUP}
+  storageAccount: sapv${RESOURCEGROUP}
 EOF
 
 cat <<EOF > /home/${AUSERNAME}/openshift-install.sh
@@ -420,6 +458,10 @@ echo "${RESOURCEGROUP} Bastion Host is starting ansible BYO" | mail -s "${RESOUR
 ansible-playbook  /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml < /dev/null
 
 wget http://master1:8443/api > healtcheck.out
+
+ansible all -b -m command -a "nmcli con modify eth0 ipv4.dns-search $(domainname -d)"
+ansible all -b -m service -a "name=NetworkManager state=restarted"
+
 ansible-playbook /home/${AUSERNAME}/postinstall.yml
 cd /root
 mkdir .kube
@@ -432,15 +474,118 @@ rm -f /tmp/kube-config
 yum -y install atomic-openshift-clients
 echo "setup registry for azure"
 oc env dc docker-registry -e REGISTRY_STORAGE=azure -e REGISTRY_STORAGE_AZURE_ACCOUNTNAME=$REGISTRYSTORAGENAME -e REGISTRY_STORAGE_AZURE_ACCOUNTKEY=$REGISTRYKEY -e REGISTRY_STORAGE_AZURE_CONTAINER=registry
+oc patch dc registry-console -p '{"spec":{"template":{"spec":{"nodeSelector":{"role":"infra"}}}}}'
 sleep 30
-echo "Setup Azure PVC"
-/home/${AUSERNAME}/createvhdcontainer.sh sapv1${RESOURCEGROUP}
-/home/${AUSERNAME}/createvhdcontainer.sh sapv2${RESOURCEGROUP}
-oc create -f /home/${AUSERNAME}/scgeneric.yml
+echo "Setup Azure PV"
+/home/${AUSERNAME}/create_azure_storage_container.sh sapv${RESOURCEGROUP} "dynamicpv"
+
+echo "Setup Azure PV for metrics & logging"
+/home/${AUSERNAME}/create_azure_storage_container.sh sapvlm${RESOURCEGROUP} "loggingmetricspv"
+
 oc adm policy add-cluster-role-to-user cluster-admin ${AUSERNAME}
 cat /home/${AUSERNAME}/openshift-install.out | tr -cd [:print:] |  mail -s "${RESOURCEGROUP} Install Complete" ${RHNUSERNAME} || true
 touch /root/.openshiftcomplete
+touch /home/${AUSERNAME}/.openshiftcomplete
 EOF
+
+cat <<EOF > /home/${AUSERNAME}/openshift-postinstall.sh
+export ANSIBLE_HOST_KEY_CHECKING=False
+
+DEPLOYMETRICS=${METRICS,,}
+DEPLOYLOGGING=${LOGGING,,}
+DEPLOYOPSLOGGING=${OPSLOGGING,,}
+
+while true
+do
+  [ -e /home/${AUSERNAME}/.openshiftcomplete ] && break || sleep 10
+done
+
+if [ \${DEPLOYMETRICS} == "true" ]
+then
+  echo "Deploying Metrics"
+  /home/${AUSERNAME}/create_pv.sh sapvlm${RESOURCEGROUP} loggingmetricspv metricspv ${METRICS_INSTANCES} ${METRICS_CASSANDRASIZE}
+  ansible-playbook -e "openshift_metrics_install_metrics=\${DEPLOYMETRICS}" /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-metrics.yml
+fi
+
+if [ \${DEPLOYLOGGING} == "true" ] || [ \${DEPLOYOPSLOGGING} == "true" ]
+then
+  if [ \${DEPLOYLOGGING} == "true" ]
+  then
+    /home/${AUSERNAME}/create_pv.sh sapvlm${RESOURCEGROUP} loggingmetricspv loggingpv ${LOGGING_ES_INSTANCES} ${LOGGING_ES_SIZE}
+    for ((i=0;i<${LOGGING_ES_INSTANCES};i++))
+    do
+      oc patch pv/loggingpv-\${i} -p '{"metadata":{"labels":{"usage":"elasticsearch"}}}'
+    done
+  fi
+
+  if [ \${DEPLOYOPSLOGGING} == true ]
+  then
+    /home/${AUSERNAME}/create_pv.sh sapvlm${RESOURCEGROUP} loggingmetricspv loggingopspv ${OPSLOGGING_ES_INSTANCES} ${OPSLOGGING_ES_SIZE}
+    for ((i=0;i<${OPSLOGGING_ES_INSTANCES};i++))
+    do
+      oc patch pv/loggingopspv-\${i} -p '{"metadata":{"labels":{"usage":"opselasticsearch"}}}'
+    done
+  fi
+  ansible-playbook -e "openshift_logging_install_logging=\${DEPLOYLOGGING} openshift_logging_use_ops=\${DEPLOYOPSLOGGING}" /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml
+fi
+
+oc create -f /home/${AUSERNAME}/scgeneric.yml
+EOF
+
+cat <<'EOF' > /home/${AUSERNAME}/create_pv.sh
+# $1 is the storage account to create container
+# $2 is the container
+# $3 is the blob
+# $4 is the times
+# $5 is the size in gigabytes
+
+mkdir -p ~/.azuresettings/$1
+export TENANT=$(< ~/.azuresettings/tenant_id)
+export AAD_CLIENT_ID=$(< ~/.azuresettings/aad_client_id)
+export AAD_CLIENT_SECRET=$(< ~/.azuresettings/aad_client_secret)
+export RESOURCEGROUP=$(< ~/.azuresettings/resource_group)
+azure login --service-principal --tenant ${TENANT}  -u ${AAD_CLIENT_ID} -p ${AAD_CLIENT_SECRET}
+azure storage account connectionstring show ${1} --resource-group ${RESOURCEGROUP} > ~/.azuresettings/$1/connection.out
+sed -n '/connectionstring:/{p}' < ~/.azuresettings/${1}/connection.out > ~/.azuresettings/${1}/dataline.out
+export DATALINE=$(< ~/.azuresettings/${1}/dataline.out)
+export AZURE_STORAGE_CONNECTION_STRING=${DATALINE:27}
+
+qemu-img create -f raw /tmp/image.raw ${5}G
+mkfs.xfs /tmp/image.raw
+qemu-img convert -f raw -o subformat=fixed -O vpc /tmp/image.raw /tmp/image.vhd
+rm -f /tmp/image.raw
+
+TIMES=$(expr ${4} - 1)
+
+for ((i=0;i<=TIMES;i++))
+do
+  azure storage blob upload /tmp/image.vhd ${2} $3-${i}.vhd
+  echo "https://${1}.blob.core.windows.net/${2}/$3-${i}.vhd"
+
+  cat<<OEF | oc create -f -
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "${3}-${i}"
+spec:
+  capacity:
+    storage: "${5}Gi"
+  accessModes:
+    - "ReadWriteOnce"
+  persistentVolumeReclaimPolicy: Delete
+  azureDisk:
+    diskName: "${3}-${i}"
+    diskURI: "https://${1}.blob.core.windows.net/${2}/${3}-${i}.vhd"
+    cachingMode: None
+    fsType: xfs
+    readOnly: false
+OEF
+done
+
+rm -f /tmp/image.vhd
+EOF
+
+chmod +x /home/${AUSERNAME}/create_pv.sh
 
 cat <<EOF > /home/${AUSERNAME}/.ansible.cfg
 [defaults]
@@ -476,4 +621,6 @@ cd /home/${AUSERNAME}
 chmod 755 /home/${AUSERNAME}/openshift-install.sh
 echo "${RESOURCEGROUP} Bastion Host is starting OpenShift Install" | mail -s "${RESOURCEGROUP} Bastion OpenShift Install Starting" ${RHNUSERNAME} || true
 /home/${AUSERNAME}/openshift-install.sh &> /home/${AUSERNAME}/openshift-install.out &
+chmod 755 /home/${AUSERNAME}/openshift-postinstall.sh
+/home/${AUSERNAME}/openshift-postinstall.sh &> /home/${AUSERNAME}/openshift-postinstall.out &
 exit 0

--- a/reference-architecture/azure-ansible/bastion.sh
+++ b/reference-architecture/azure-ansible/bastion.sh
@@ -477,7 +477,7 @@ oc env dc docker-registry -e REGISTRY_STORAGE=azure -e REGISTRY_STORAGE_AZURE_AC
 oc patch dc registry-console -p '{"spec":{"template":{"spec":{"nodeSelector":{"role":"infra"}}}}}'
 sleep 30
 echo "Setup Azure PV"
-/home/${AUSERNAME}/create_azure_storage_container.sh sapv${RESOURCEGROUP} "dynamicpv"
+/home/${AUSERNAME}/create_azure_storage_container.sh sapv${RESOURCEGROUP} "vhds"
 
 echo "Setup Azure PV for metrics & logging"
 /home/${AUSERNAME}/create_azure_storage_container.sh sapvlm${RESOURCEGROUP} "loggingmetricspv"


### PR DESCRIPTION
#### What does this PR do?
* Optionally deploys OCP metrics by setting a parameter in the ARM template or the ansible vars (true by default)
* Metrics components are deployed as 1 cassandra, 1 hawkular-metrics and 1 heapster pod (enough for 25000 pods[1])
* Cassandra uses a PV dedicated (xfs azure disk)
* Optionally deploys OCP logging by setting a parameter in the ARM template or the ansible vars (true by default) and OPS logging as well (false by default)
* Logging architecture is 1 fluentd pod (daemonset) on each host (including masters), 3 elasticsearch pods, 2 kibana and 1 curator for HA (specially the elasticsearch)
* OPS logging same architecture
* Dedicated 10Gb PV for every elasticsearch pod
* HA and disk size is easily configurable using variables in bastion.sh
* `enable-controller-attach-detach': ['true']` parameter as it looks like it is the proper way (and it will be by default in next releases[2])
* Renamed storage accounts with a proper naming
* Proper order in nodes labels (like masters or infranodes)
* Fix for hosts to be able to DNS resolve without using the full domainname
* Registry console node selector to be deployed in the infranodes instead regular ones

#### How should this be manually tested?
Run the installation using ansible or the Azure portal with the metrics, logging and ops logging parameters to "true" and after installation, check logging, ops logging and metrics pods, it should look like:

```
$ oc get pods --all-namespaces -o wide
NAMESPACE         NAME                              READY     STATUS    RESTARTS   AGE       IP            NODE
asdf              guestbook-1-1dj2v                 1/1       Running   0          49m       10.129.2.5    node01
asdf              guestbook-1-lmbcb                 1/1       Running   0          49m       10.128.4.4    node02
asdf              guestbook-1-wk6gz                 1/1       Running   0          49m       10.131.2.5    node03
default           docker-registry-2-5wblb           1/1       Running   0          1h        10.130.0.4    infranode3
default           registry-console-2-cb5mn          1/1       Running   0          1h        10.128.0.2    infranode1
default           router-1-6kmdn                    1/1       Running   0          1h        10.0.2.4      infranode2
default           router-1-qxj23                    1/1       Running   0          1h        10.0.2.5      infranode3
default           router-1-xsvb3                    1/1       Running   0          1h        10.0.2.6      infranode1
logging           logging-curator-1-z9khd           1/1       Running   4          58m       10.128.0.13   infranode1
logging           logging-curator-ops-1-j2sxm       1/1       Running   5          58m       10.128.2.11   infranode2
logging           logging-es-0usf83ay-1-nlsz8       1/1       Running   7          58m       10.128.0.16   infranode1
logging           logging-es-690ebmic-1-kt4sl       1/1       Running   7          58m       10.128.2.12   infranode2
logging           logging-es-ops-b44n3gav-1-zkl3r   1/1       Running   7          58m       10.128.0.17   infranode1
logging           logging-es-ops-j7n7g1rw-1-wrw14   1/1       Running   7          58m       10.130.0.10   infranode3
logging           logging-es-ops-xlzj28qv-1-hc10k   1/1       Running   7          58m       10.128.2.13   infranode2
logging           logging-es-r58jbl8f-1-s6zn1       1/1       Running   7          58m       10.130.0.9    infranode3
logging           logging-fluentd-19fg0             1/1       Running   0          57m       10.131.2.3    node03
logging           logging-fluentd-1nxgn             1/1       Running   0          58m       10.131.0.3    master2
logging           logging-fluentd-355kc             1/1       Running   0          57m       10.128.4.3    node02
logging           logging-fluentd-5twkg             1/1       Running   0          57m       10.129.0.3    master3
logging           logging-fluentd-blmmm             1/1       Running   0          57m       10.130.2.3    master1
logging           logging-fluentd-cjzj1             1/1       Running   0          57m       10.128.0.15   infranode1
logging           logging-fluentd-g5jqw             1/1       Running   0          58m       10.130.0.8    infranode3
logging           logging-fluentd-nb62x             1/1       Running   0          58m       10.129.2.4    node01
logging           logging-fluentd-rn0xc             1/1       Running   0          58m       10.128.2.10   infranode2
logging           logging-kibana-1-1m90g            2/2       Running   0          58m       10.128.0.12   infranode1
logging           logging-kibana-ops-1-1w11q        2/2       Running   0          58m       10.128.0.14   infranode1
openshift-infra   hawkular-cassandra-1-h9mrq        1/1       Running   0          1h        10.130.0.6    infranode3
openshift-infra   hawkular-metrics-7scbw            1/1       Running   0          1h        10.128.2.5    infranode2
openshift-infra   heapster-32xhg                    1/1       Running   0          1h        10.130.0.5    infranode3
```

#### Is there a relevant Issue open for this?

* Lots of Azure issues[3][4][5][6] made me go for the post-installation steps instead for an "out-of-the-box" experience
* Logging doesn't work right now because of this bug[3], but editing the configmap fixes it

#### Who would you like to review this?
cc: @glennswest  @cooktheryan 

[1] https://docs.openshift.com/container-platform/3.5/scaling_performance/scaling_cluster_metrics.html#cluster-metrics-scaling-openshift-metrics-pods
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1467970#c6
[3] https://bugzilla.redhat.com/show_bug.cgi?id=1467970
[4] https://bugzilla.redhat.com/show_bug.cgi?id=1467575
[5] https://bugzilla.redhat.com/show_bug.cgi?id=1469001
[6] https://bugzilla.redhat.com/show_bug.cgi?id=1467966
[7] https://bugzilla.redhat.com/show_bug.cgi?id=1466626