### PR TITLE
Add defaults values for some openstack vars

### DIFF
--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -14,7 +14,7 @@
   become: true
   roles:
   - role: subscription-manager
-    when: hostvars.localhost.rhsm_register
+    when: hostvars.localhost.rhsm_register|default(False)
     tags: 'subscription-manager'
 
 - name: Determine which DNS server(s) to use for our generated records

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -56,5 +56,5 @@ openstack_subnet_prefix: "192.168.99"
 # hardcoded to `openshift`.
 ansible_user: openshift
 
-# # Use a single security group for a cluster
-openstack_flat_secgrp: false
+# # Use a single security group for a cluster (default: false)
+#openstack_flat_secgrp: false

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -160,7 +160,7 @@ resources:
           protocol: icmp
           remote_ip_prefix: {{ ssh_ingress_cidr }}
 
-{% if openstack_flat_secgrp|bool %}
+{% if openstack_flat_secgrp|default(False)|bool %}
   flat-secgrp:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -481,7 +481,7 @@ resources:
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
           secgrp:
-            - { get_resource: {% if openstack_flat_secgrp|bool %}flat-secgrp{% else %}etcd-secgrp{% endif %} }
+            - { get_resource: {% if openstack_flat_secgrp|default(False)|bool %}flat-secgrp{% else %}etcd-secgrp{% endif %} }
             - { get_resource: common-secgrp }
           floating_network: {{ external_network }}
           net_name:
@@ -563,7 +563,7 @@ resources:
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
           secgrp:
-{% if openstack_flat_secgrp|bool %}
+{% if openstack_flat_secgrp|default(False)|bool %}
             - { get_resource: flat-secgrp }
 {% else %}
             - { get_resource: master-secgrp }
@@ -617,7 +617,7 @@ resources:
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
           secgrp:
-            - { get_resource: {% if openstack_flat_secgrp|bool %}flat-secgrp{% else %}node-secgrp{% endif %} }
+            - { get_resource: {% if openstack_flat_secgrp|default(False)|bool %}flat-secgrp{% else %}node-secgrp{% endif %} }
             - { get_resource: common-secgrp }
           floating_network: {{ external_network }}
           net_name:
@@ -662,7 +662,7 @@ resources:
           subnet:      { get_resource: subnet }
           secgrp:
 # TODO(bogdando) filter only required node rules into infra-secgrp
-{% if openstack_flat_secgrp|bool %}
+{% if openstack_flat_secgrp|default(False)|bool %}
             - { get_resource: flat-secgrp }
 {% else %}
             - { get_resource: node-secgrp }
@@ -718,4 +718,3 @@ resources:
           volume_size: {{ dns_volume_size }}
     depends_on:
       - interface
-


### PR DESCRIPTION
#### What does this PR do?

Ansible shows errors when the `rhsm_register` and
`openstack_flat_secgrp` values are not present in the inventory even
though they have sensible default values.

This makes them both default to false when they're not specified.

#### How should this be manually tested?

Remove `openstack_flat_secgrp` and `rhsm_register` values from your inventory's  `group_vars/all.yml` an run the openstack provisioning playbook (on centos -- since we're not subscribing to red hat).

The deployment should succeed as if both vars were there and set to `false`.

#### Is there a relevant Issue open for this?
N\A

#### Who would you like to review this?
cc: @bogdando PTAL
