### PR TITLE
Switch the sample inventory to CentOS

### DIFF
--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -1,5 +1,6 @@
 ---
 openshift_deployment_type: origin
+openshift_release: 1.5.1
 #openshift_deployment_type: openshift-enterprise
 #openshift_release: v3.5
 openshift_master_default_subdomain: "apps.{{ env_id }}.{{ public_dns_domain }}"

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -1,6 +1,7 @@
 ---
-openshift_deployment_type: openshift-enterprise
-openshift_release: v3.5
+openshift_deployment_type: origin
+#openshift_deployment_type: openshift-enterprise
+#openshift_release: v3.5
 openshift_master_default_subdomain: "apps.{{ env_id }}.{{ public_dns_domain }}"
 
 # NOTE(shadower): do not remove this line, otherwise the default node labels
@@ -8,6 +9,11 @@ openshift_master_default_subdomain: "apps.{{ env_id }}.{{ public_dns_domain }}"
 openshift_node_labels: "{{ openstack.metadata.node_labels }}"
 
 osm_default_node_selector: 'region=primary'
+
+# NOTE(shadower): the hostname check seems to always fail because the
+# host's floating IP address doesn't match the address received from
+# inside the host.
+openshift_override_hostname_check: true
 
 # For POCs or demo environments that are using smaller instances than
 # the official recommended values for RAM and DISK, uncomment the line below.

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -4,7 +4,7 @@ public_dns_domain: "example.com"
 public_dns_nameservers: []
 
 openstack_ssh_public_key: "openshift"
-openstack_default_image_name: "rhel73"
+openstack_default_image_name: "centos7"
 openstack_default_flavor: "m1.medium"
 openstack_external_network_name: "public"
 
@@ -20,6 +20,8 @@ docker_volume_size: "15"
 openstack_subnet_prefix: "192.168.99"
 
 # # Red Hat subscription
+rhsm_register: False
+
 # # Using Red Hat Satellite:
 #rhsm_register: True
 #rhsm_satellite: 'sat-6.example.com'


### PR DESCRIPTION
#### What does this PR do?
This changes the image name and deployment types to use centos instead
of rhel and sets `rhsm_register` to false.

With these changes, the inventory should be immediately deployable
using the default values (assuming the image, network and flavor names
match).

Ideally, the upstream CI will just end up using this inventory with
little to no changes, too at some point.


#### How should this be manually tested?

Copy the updated sample-inventory, make sure the image, network and flavor names match and test it end to end without any additional changes. The deployment should succeed with Origin running on CentOS servers.

#### Is there a relevant Issue open for this?
nona

#### Who would you like to review this?
cc: @bogdando PTAL
