### PR TITLE
Set up NetworkManager automatically

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -181,11 +181,8 @@ file, this is how you stat the provisioning process:
 
 Once it succeeds, you can install openshift by running:
 
-    ansible-playbook --become --user openshift --private-key ~/.ssh/openshift -i inventory/ openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
     ansible-playbook --become --user openshift --private-key ~/.ssh/openshift -i inventory/ openshift-ansible/playbooks/byo/config.yml
 
-Note, the `network_manager.yml` step is mandatory and is required for persisting
-the hosts' DNS configs.
 
 ## License
 

--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -59,12 +59,20 @@
 
 - name: OpenShift Pre-Requisites
   hosts: OSEv3
-  gather_facts: False
+  gather_facts: true
   become: true
-  tasks:
+  pre_tasks:
   - name: "Include DNS configuration to ensure proper name resolution"
     lineinfile:
       state: present
       dest: /etc/sysconfig/network
       regexp: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
       line: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
+  roles:
+  # CentOS isn't using NetworkManager by default. Make sure it's installed:
+  - role: node-network-manager
+    when: ansible_distribution == "CentOS"
+  tasks:
+  - name: Restart NetworkManager to pick up the DNS changes
+    service: name=NetworkManager state=restarted
+    when: ansible_distribution == 'Red Hat Enterprise Linux'

--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -69,10 +69,4 @@
       regexp: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
       line: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
   roles:
-  # CentOS isn't using NetworkManager by default. Make sure it's installed:
-  - role: node-network-manager
-    when: ansible_distribution == "CentOS"
-  tasks:
-  - name: Restart NetworkManager to pick up the DNS changes
-    service: name=NetworkManager state=restarted
-    when: ansible_distribution == 'Red Hat Enterprise Linux'
+  - node-network-manager

--- a/roles/node-network-manager/tasks/main.yml
+++ b/roles/node-network-manager/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: install NetworkManager
+  package:
+    name: NetworkManager
+    state: present
+
+- name: configure NetworkManager
+  lineinfile:
+    dest: "/etc/sysconfig/network-scripts/ifcfg-{{ ansible_default_ipv4['interface'] }}"
+    regexp: '^{{ item }}='
+    line: '{{ item }}=yes'
+    state: present
+    create: yes
+  with_items:
+  - 'USE_PEERDNS'
+  - 'NM_CONTROLLED'
+
+- name: enable and start NetworkManager
+  service:
+    name: NetworkManager
+    state: started
+    enabled: yes

--- a/roles/node-network-manager/tasks/main.yml
+++ b/roles/node-network-manager/tasks/main.yml
@@ -18,5 +18,5 @@
 - name: enable and start NetworkManager
   service:
     name: NetworkManager
-    state: started
+    state: restarted
     enabled: yes


### PR DESCRIPTION
#### What does this PR do?

This removes the extra step of running the
`openshift-ansible/playbooks/byo/openshift-node/network_manager.yml`
before installing openshift. In addition, the playbook relies on a
host group that the provisioning doesn't provide (oo_all_hosts).

Instead, we set up NetworkManager on CentOS nodes automatically. And
we restart it on RHEL (which is necessary for the nodes to pick up the
new DNS we configured the subnet with).

This makes the provisioning easier and more resilient.


#### How should this be manually tested?

Run an end-to-end deployment on RHEL+Enterprise and Centos+Origin without running the network_manager playbooks.

#### Is there a relevant Issue open for this?
none

#### Who would you like to review this?
cc: @Tlacenka  @bogdando PTAL
