### PR TITLE
add missing ansible rpm to sample command

### DIFF
--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -16,7 +16,7 @@ The code in this repository handles all of the AWS specific components except fo
 $ subscription-manager repos --enable rhel-7-server-optional-rpms
 $ subscription-manager repos --enable rhel-7-server-ose-3.5-rpms
 $ subscription-manager repos --enable rhel-7-fast-datapath-rpms
-$ yum -y install atomic-openshift-utils ansible
+$ yum -y install atomic-openshift-utils ansible openshift-ansible-playbooks
 $ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 $ yum -y install python2-boto \
                  pyOpenSSL \


### PR DESCRIPTION
#### What does this PR do?
This adds openshift-ansible-playbooks to yum install command. It's instructed in readme, but forgotten to put into sample

#### How should this be manually tested?

This is run from a machine that has the rpm installed.
rpm -qa openshift-ansible-playbooks
openshift-ansible-playbooks-3.4.110-1.git.0.7d78794.el7.noarch


#### Is there a relevant Issue open for this?
Nope, RH customer just emailed me he failed to install and asked where to find the ansibles. It's explained in the README, but command is  missing from the sample.


#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
