### PR TITLE
Replace greaterthan and equalto in openstack-stack

### DIFF
--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -432,7 +432,7 @@ resources:
           port_range_min: 53
           port_range_max: 53
           remote_ip_prefix: "{{ openstack_subnet_prefix }}.0/24"
-{% if num_masters is greaterthan 1 %}
+{% if num_masters > 1 %}
   lb-secgrp:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -444,7 +444,7 @@ resources:
         port_range_min: {{ openshift_master_api_port | default(8443) }}
         port_range_max: {{ openshift_master_api_port | default(8443) }}
         remote_ip_prefix: {{ lb_ingress_cidr }}
-  {% if openshift_master_console_port is defined and openshift_master_console_port is not equalto openshift_master_api_port %}
+  {% if openshift_master_console_port is defined and openshift_master_console_port != openshift_master_api_port %}
       - direction: ingress
         protocol: tcp
         port_range_min: {{ openshift_master_console_port | default(8443) }}
@@ -493,7 +493,7 @@ resources:
     depends_on:
       - interface
 
-{% if num_masters is greaterthan 1 %}
+{% if num_masters > 1 %}
   loadbalancer:
     type: OS::Heat::ResourceGroup
     properties:
@@ -568,7 +568,7 @@ resources:
 {% else %}
             - { get_resource: master-secgrp }
             - { get_resource: node-secgrp }
-{% if num_etcd is equalto 0 %}
+{% if num_etcd == 0 %}
             - { get_resource: etcd-secgrp }
 {% endif %}
 {% endif %}


### PR DESCRIPTION
#### What does this PR do?

The `greaterthan` and `equalto` Jinja filters were added in 2.8 which is notably not packaged in
CentOS and RHEL. This removes them in favour of the `==` and `>` operators
which are available in Jinja 2.7.

#### How should this be manually tested?

Make sure your jinja2 version is 2.7 (e.g. by running `pip uninstall Jinja2 && pip install --user Jinja2=2.7.2`) and run the provisioning part of the deployment (full end to end isn't strictly speaking necessary).

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @bogdando 
