### PR TITLE
Add bastion and ssh config for the static inventory role

### DIFF
--- a/roles/static_inventory/defaults/main.yml
+++ b/roles/static_inventory/defaults/main.yml
@@ -4,5 +4,18 @@ refresh_inventory: True
 inventory: static
 inventory_path: ~/openstack-inventory
 
+# Either to configure bastion
+use_bastion: true
+
+# SSH user/key/options to access hosts via bastion
+ssh_user: openshift
+ssh_options: >-
+  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+  -o ConnectTimeout=90 -o ControlMaster=auto -o ControlPersist=270s
+  -o ServerAliveInterval=30 -o GSSAPIAuthentication=no
+
 # SSH key to access nodes
 private_ssh_key: ~/.ssh/openshift
+
+# The patch to store the generated config to access bastion/hosts
+ssh_config_path: /tmp/ssh.config.ansible

--- a/roles/static_inventory/tasks/main.yml
+++ b/roles/static_inventory/tasks/main.yml
@@ -4,3 +4,7 @@
 
 - name: Checkpoint in-memory data into a static inventory
   include: checkpoint.yml
+
+- name: Generate SSH config for accessing hosts via bastion
+  include: sshconfig.yml
+  when: use_bastion|bool

--- a/roles/static_inventory/tasks/openstack.yml
+++ b/roles/static_inventory/tasks/openstack.yml
@@ -16,12 +16,14 @@
 
     - name: set_fact for openstack inventory nodes
       set_fact:
+        registered_bastion_nodes: "{{ (registered_nodes_output.stdout | from_json) | json_query(q) }}"
         registered_nodes_floating: "{{ (registered_nodes_output.stdout | from_json) | json_query(q2) }}"
       vars:
         q: "[] | [?metadata.group=='infra.{{stack_name}}']"
         q2: "[] | [?metadata.clusterid=='{{stack_name}}'] | [?public_v4!='']"
       when:
         - refresh_inventory|bool
+        - use_bastion|bool
 
     - name: Add cluster nodes w/o floating IPs to inventory
       with_items: "{{ registered_nodes }}"
@@ -29,9 +31,11 @@
       add_host:
         name: '{{ item.name }}'
         groups: '{{ item.metadata.group }}'
-        ansible_host: '{{ item.private_v4 }}'
+        ansible_host: "{% if use_bastion|bool %}{{ item.name }}{% else %}{{ item.private_v4 }}{% endif %}"
         ansible_fqdn: '{{ item.name }}'
+        ansible_user: '{{ ssh_user }}'
         ansible_private_key_file: '{{ private_ssh_key }}'
+        ansible_ssh_extra_args: '-F {{ ssh_config_path }}'
         private_v4: '{{ item.private_v4 }}'
 
     - name: Add cluster nodes with floating IPs to inventory
@@ -40,8 +44,25 @@
       add_host:
         name: '{{ item.name }}'
         groups: '{{ item.metadata.group }}'
-        ansible_host: '{{ item.public_v4 }}'
+        ansible_host: "{% if use_bastion|bool %}{{ item.name }}{% else %}{{ item.private_v4 }}{% endif %}"
         ansible_fqdn: '{{ item.name }}'
+        ansible_user: '{{ ssh_user }}'
         ansible_private_key_file: '{{ private_ssh_key }}'
+        ansible_ssh_extra_args: '-F {{ ssh_config_path }}'
         private_v4: '{{ item.private_v4 }}'
         public_v4: '{{ item.public_v4 }}'
+
+    - name: Add bastion node to inventory
+      add_host:
+        name: bastion
+        groups: bastions
+        ansible_host: '{{ registered_bastion_nodes[0].public_v4 }}'
+        ansible_fqdn: '{{ registered_bastion_nodes[0].name }}'
+        ansible_user: '{{ ssh_user }}'
+        ansible_private_key_file: '{{ private_ssh_key }}'
+        ansible_ssh_extra_args: '-F {{ ssh_config_path }}'
+        private_v4: '{{ registered_bastion_nodes[0].private_v4 }}'
+        public_v4: '{{ registered_bastion_nodes[0].public_v4 }}'
+      when:
+        - registered_bastion_nodes is defined
+        - use_bastion|bool

--- a/roles/static_inventory/tasks/sshconfig.yml
+++ b/roles/static_inventory/tasks/sshconfig.yml
@@ -1,0 +1,13 @@
+---
+- name: set ssh proxy command prefix for accessing nodes via bastion
+  set_fact:
+    ssh_proxy_command: >-
+      ssh {{ ssh_options }}
+      -i {{ private_ssh_key }}
+      {{ ssh_user }}@{{ hostvars['bastion'].ansible_host }}
+
+- name: regenerate ssh config
+  template:
+    src: openstack_ssh_config.j2
+    dest: "{{ ssh_config_path }}"
+    mode: 0644

--- a/roles/static_inventory/templates/inventory.j2
+++ b/roles/static_inventory/templates/inventory.j2
@@ -10,8 +10,12 @@
 %} private_v4={{ hostvars[host]['private_v4'] }}{% endif %}
 {% if 'public_v4' in hostvars[host]
 %} public_v4={{ hostvars[host]['public_v4'] }}{% endif %}
+{% if 'ansible_user' in hostvars[host]
+%} ansible_user={{ hostvars[host]['ansible_user'] }}{% endif %}
 {% if 'ansible_private_key_file' in hostvars[host]
 %} ansible_private_key_file={{ hostvars[host]['ansible_private_key_file'] }}{% endif %}
+{% if 'ansible_ssh_extra_args' in hostvars[host]
+%} ansible_ssh_extra_args={{ hostvars[host]['ansible_ssh_extra_args']|quote }}{% endif %}
 
 {% endif %}
 {% endfor %}

--- a/roles/static_inventory/templates/openstack_ssh_config.j2
+++ b/roles/static_inventory/templates/openstack_ssh_config.j2
@@ -1,0 +1,21 @@
+Host *
+    IdentitiesOnly yes
+
+Host bastion
+    Hostname {{ hostvars['bastion'].ansible_host }}
+    IdentityFile {{ hostvars['bastion'].ansible_private_key_file }}
+    User {{ ssh_user }}
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null
+
+{% for host in groups['all'] | difference(groups['bastions'][0]) %}
+
+Host {{ host }}
+    Hostname {{ hostvars[host].ansible_host }}
+    ProxyCommand {{ ssh_proxy_command  }} -W {{ hostvars[host].private_v4 }}:22
+    IdentityFile {{ hostvars[host].ansible_private_key_file }}
+    User {{ ssh_user }}
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null
+
+{% endfor %}


### PR DESCRIPTION
#### What does this PR do?

* Autogenerate SSH config for static inventory and bastion.
* When using bastion, use FQDN for inventory's ansible_host and SSH
  config's Hostname. Simplifies accessing nodes by names instead of
  private IPs.

#### How should this be manually tested?
e2e with `use_bastion: true`

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
cc: @tomassedovic PTAL
