### PR TITLE
Static inventory autogeneration

### DIFF
--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -1,72 +1,90 @@
 ---
+- hosts: cluster_hosts
+  name: Wait for the the nodes to come up
+  become: False
+  gather_facts: False
+  tasks:
+    - wait_for_connection:
+
+- hosts: cluster_hosts
+  gather_facts: True
+  tasks:
+    - name: Debug hostvar
+      debug:
+        msg: "{{ hostvars[inventory_hostname] }}"
+        verbosity: 2
+
+- name: OpenShift Pre-Requisites (part 1)
+  include: pre-install.yml
+
 - name: Assign hostnames
   hosts: cluster_hosts
   gather_facts: False
   become: true
   pre_tasks:
-  - include: pre_tasks.yml
+    - include: pre_tasks.yml
   roles:
-  - role: hostnames
+    - role: hostnames
 
 - name: Subscribe DNS Host to allow for configuration below
   hosts: dns
   gather_facts: False
   become: true
   roles:
-  - role: subscription-manager
-    when: hostvars.localhost.rhsm_register|default(False)
-    tags: 'subscription-manager'
+    - role: subscription-manager
+      when: hostvars.localhost.rhsm_register|default(False)
+      tags: 'subscription-manager'
 
 - name: Determine which DNS server(s) to use for our generated records
   hosts: localhost
   gather_facts: False
   become: False
   roles:
-  - dns-server-detect
+    - dns-server-detect
 
 - name: Build the DNS Server Views and Configure DNS Server(s)
   hosts: dns
   gather_facts: False
   become: true
   pre_tasks:
-  - include: pre_tasks.yml
-  - name: "Generate dns-server views"
-    include: openstack_dns_views.yml
+    - include: pre_tasks.yml
+    - name: "Generate dns-server views"
+      include: openstack_dns_views.yml
   roles:
-  - role: infra-ansible/roles/dns-server
+    - role: infra-ansible/roles/dns-server
 
 - name: Build and process DNS Records
   hosts: localhost
-  gather_facts: False
+  gather_facts: True
   become: False
   pre_tasks:
-  - include: pre_tasks.yml
-  - name: "Generate dns records"
-    include: openstack_dns_records.yml
+    - include: pre_tasks.yml
+    - name: "Generate dns records"
+      include: openstack_dns_records.yml
   roles:
-  - role: infra-ansible/roles/dns
+    - role: infra-ansible/roles/dns
 
 - name: Switch the stack subnet to the configured private DNS server
   hosts: localhost
   gather_facts: False
   become: False
   vars_files:
-  - stack_params.yaml
+    - stack_params.yaml
   tasks:
-  - include_role:
-      name: openstack-stack
-      tasks_from: subnet_update_dns_servers
+    - include_role:
+        name: openstack-stack
+        tasks_from: subnet_update_dns_servers
 
-- name: OpenShift Pre-Requisites
+- name: OpenShift Pre-Requisites (part 2)
   hosts: OSEv3
   gather_facts: true
   become: true
   pre_tasks:
-  - name: "Include DNS configuration to ensure proper name resolution"
-    lineinfile:
-      state: present
-      dest: /etc/sysconfig/network
-      regexp: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
-      line: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
+    - name: "Include DNS configuration to ensure proper name resolution"
+      lineinfile:
+        state: present
+        dest: /etc/sysconfig/network
+        regexp: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
+        line: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
   roles:
-  - node-network-manager
+    - node-network-manager

--- a/playbooks/provisioning/openstack/provision-openstack.yml
+++ b/playbooks/provisioning/openstack/provision-openstack.yml
@@ -8,6 +8,10 @@
     - include: pre_tasks.yml
   roles:
     - role: openstack-stack
+    - role: static_inventory
+      when: openstack_inventory|default('static') == 'static'
+      inventory_path: "{{ openstack_inventory_path|default(inventory_dir) }}"
+      private_ssh_key: "{{ openstack_private_ssh_key|default('~/.ssh/id_rsa') }}"
 
 - name: Refresh Server inventory
   hosts: localhost
@@ -16,20 +20,5 @@
   gather_facts: False
   tasks:
     - meta: refresh_inventory
-
-- hosts: cluster_hosts
-  name: Wait for the the nodes to come up
-  become: False
-  gather_facts: False
-  tasks:
-    - wait_for_connection:
-
-- hosts: cluster_hosts
-  gather_facts: True
-  tasks:
-    - name: Debug hostvar
-      debug:
-        msg: "{{ hostvars[inventory_hostname] }}"
-        verbosity: 2
 
 - include: post-provision-openstack.yml

--- a/playbooks/provisioning/openstack/provision.yaml
+++ b/playbooks/provisioning/openstack/provision.yaml
@@ -2,5 +2,3 @@
 - include: "prerequisites.yml"
 
 - include: "provision-openstack.yml"
-
-- include: "pre-install.yml"

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -60,3 +60,14 @@ ansible_user: openshift
 
 # # Use a single security group for a cluster (default: false)
 #openstack_flat_secgrp: false
+
+# # Openstack inventory type and cluster nodes access pattern
+# # Defaults to 'static'.
+# # Use 'dynamic' to access cluster nodes directly, via floating IPs
+# # and given a dynamic inventory script, like openstack.py
+#openstack_inventory: static
+# # The path to checkpoint the static inventory from the in-memory one
+#openstack_inventory_path: ../../../../inventory
+
+# # The Nova key-pair's private SSH key to access inventory nodes
+#openstack_private_ssh_key: ~/.ssh/openshift


### PR DESCRIPTION
#### What does this PR do?
* At the provisioning stage, allow users to auto-generate a static
  inventory w/o manual steps needed. The alternative to
  go fully dynamic TBD.
* Move openshift pre-install playbook to the post provision playbook,
  where the second part of the pre install tasks is already placed.

Depends-on https://github.com/openshift/openshift-ansible-contrib/pull/538

#### How should this be manually tested?
e2e with `inventory: static`

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
cc: @tomassedovic PTAL
