### PR TITLE
Retry tasks in the subscription manager role

### DIFF
--- a/roles/subscription-manager/tasks/main.yml
+++ b/roles/subscription-manager/tasks/main.yml
@@ -73,7 +73,7 @@
     - rhsm_satellite is defined
     - rhsm_satellite is not none
     - rhsm_satellite|trim != ''
-  regster: register_key_result
+  register: register_key_result
   until: register_key_result.rc == 0
   retries: 10
   delay: 1

--- a/roles/subscription-manager/tasks/main.yml
+++ b/roles/subscription-manager/tasks/main.yml
@@ -52,6 +52,8 @@
   when:
     - not registered
     - rhsm_authentication is defined
+  retries: 10
+  delay: 1
 
 - name: "Install Satellite certificate"
   command: "rpm -Uvh --force http://{{ rhsm_satellite }}/pub/katello-ca-consumer-latest.noarch.rpm"
@@ -69,6 +71,8 @@
     - rhsm_satellite is defined
     - rhsm_satellite is not none
     - rhsm_satellite|trim != ''
+  retries: 10
+  delay: 1
 
 # This can apply to either Hosted or Satellite
 - name: "Register using username and password"
@@ -78,6 +82,8 @@
     - not registered
     - rhsm_authentication == "password"
     - rhsm_org is not defined or rhsm_org is none or rhsm_org|trim == ''
+  retries: 10
+  delay: 1
 
 # This can apply to either Hosted or Satellite
 - name: "Register using username, password and organization"
@@ -89,12 +95,16 @@
     - rhsm_org is defined
     - rhsm_org is not none
     - rhsm_org|trim != ''
+  retries: 10
+  delay: 1
 
 - name: "Auto-attach to Subscription Manager Pool"
   command: "/usr/bin/subscription-manager attach --auto"
   when:
     - not registered
     - rhsm_pool is undefined or rhsm_pool is none or rhsm_pool|trim == ''
+  retries: 10
+  delay: 1
 
 - name: "Attach to a specific pool"
   command: "/usr/bin/subscription-manager attach --pool={{ rhsm_pool }}"
@@ -103,6 +113,8 @@
     - rhsm_pool is not none
     - rhsm_pool|trim != ''
     - not registered
+  retries: 10
+  delay: 1
 
 - name: "Disable all repositories"
   command: "/usr/bin/subscription-manager repos --disable=*"
@@ -120,3 +132,5 @@
     - rhsm_repos is defined
     - rhsm_repos is not none
     - rhsm_repos|trim != ''
+  retries: 10
+  delay: 1

--- a/roles/subscription-manager/tasks/main.yml
+++ b/roles/subscription-manager/tasks/main.yml
@@ -52,6 +52,8 @@
   when:
     - not registered
     - rhsm_authentication is defined
+  register: cleaningsubs_result
+  until: cleaningsubs_result.rc == 0
   retries: 10
   delay: 1
 
@@ -71,6 +73,8 @@
     - rhsm_satellite is defined
     - rhsm_satellite is not none
     - rhsm_satellite|trim != ''
+  regster: register_key_result
+  until: register_key_result.rc == 0
   retries: 10
   delay: 1
 
@@ -82,6 +86,8 @@
     - not registered
     - rhsm_authentication == "password"
     - rhsm_org is not defined or rhsm_org is none or rhsm_org|trim == ''
+  register: register_userpw_result
+  until: register_userpw_result.rc == 0
   retries: 10
   delay: 1
 
@@ -95,6 +101,8 @@
     - rhsm_org is defined
     - rhsm_org is not none
     - rhsm_org|trim != ''
+  register: register_userpworg_result
+  until: register_userpworg_result.rc == 0
   retries: 10
   delay: 1
 
@@ -103,6 +111,8 @@
   when:
     - not registered
     - rhsm_pool is undefined or rhsm_pool is none or rhsm_pool|trim == ''
+  register: autoattach_result
+  until: autoattach_result.rc == 0
   retries: 10
   delay: 1
 
@@ -113,6 +123,8 @@
     - rhsm_pool is not none
     - rhsm_pool|trim != ''
     - not registered
+  register: attachpool_result
+  until: attachpool_result.rc == 0
   retries: 10
   delay: 1
 
@@ -132,5 +144,7 @@
     - rhsm_repos is defined
     - rhsm_repos is not none
     - rhsm_repos|trim != ''
+  register: enablerepos_result
+  until: enablerepos_result.rc == 0
   retries: 10
   delay: 1


### PR DESCRIPTION
#### What does this PR do?
Some subscription manager role tasks (such as subscription or attaching pool) are now retried by ansible, so that even during slow internet connection, the chance of failure is decreased.

#### How should this be manually tested?
1) To make sure that subscription manager tasks fails and is retried, enter wrong credentials in your inventory used for provisioning.
2) Run provisioning using rhel images.
3) Ansible will retry to subscribe using wrong credentials and fail at the end.

#### Is there a relevant Issue open for this?
-------------

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
