### PR TITLE
Slightly enhanced deployment manager role

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/roles/deployment-create/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/deployment-create/tasks/main.yaml
@@ -11,9 +11,16 @@
   changed_when: false
   ignore_errors: true
 
+- name: delete deployment if it exists in failed state
+  include_role:
+    name: deployment-delete
+  when:
+  - deployment_exists | succeeded
+  - (deployment_exists.stdout | from_yaml).operation.error is defined
+
 - name: create deployment {{ deployment_name_with_prefix }}
   command: gcloud --project {{ gcloud_project }} deployment-manager deployments create {{ deployment_name_with_prefix }} --config '{{ deployment_config }}'
-  when: deployment_exists | failed
+  when: deployment_exists | failed or (deployment_exists.stdout | from_yaml).operation.error is defined
 
 - name: update deployment {{ deployment_name_with_prefix }}
   command: gcloud --project {{ gcloud_project }} deployment-manager deployments update {{ deployment_name_with_prefix }} --config '{{ deployment_config }}'

--- a/reference-architecture/gce-cli/ansible/playbooks/roles/gold-image/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/gold-image/tasks/main.yaml
@@ -4,6 +4,7 @@
     name: deployment-create
   vars:
     deployment_name: gold-image
+    deployment_name_with_prefix: '{{ prefix }}-{{ deployment_name }}{{ "-origin" if openshift_deployment_type == "origin" }}'
 
 - name: delete temp instance disk
   gce_pd:

--- a/reference-architecture/gce-cli/ansible/playbooks/teardown.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/teardown.yaml
@@ -21,6 +21,7 @@
   - ssh-proxy-delete
   - role: deployment-delete
     deployment_name: gold-image
+    deployment_name_with_prefix: '{{ prefix }}-{{ deployment_name }}{{ "-origin" if openshift_deployment_type == "origin" }}'
     when: delete_gold_image | bool
   - role: rhel-image-delete
     when: delete_image | bool


### PR DESCRIPTION
#### What does this PR do?
More robust deployment manager role - if there already exists deployment in failed state - delete it and redeploy. This PR also enables to have gold images for both, enterprise and origin deployment present in one gcp project.

#### How should this be manually tested?
Verify that deployment works for both, enterprise and origin deployments.

#### Is there a relevant Issue open for this?
Resolves: #438

#### Who would you like to review this?
cc: @bdurrow @e-minguez @cooktheryan PTAL