### PR TITLE
Include masters into etcd group, when it is empty

### DIFF
--- a/roles/static_inventory/templates/inventory.j2
+++ b/roles/static_inventory/templates/inventory.j2
@@ -44,6 +44,7 @@ masters.{{ stack_name }}
 
 [etcd:children]
 etcd.{{ stack_name }}
+{% if 'etcd' not in groups or groups['etcd']|length == 0 %}masters.{{ stack_name }}{% endif %}
 
 [nodes:children]
 masters


### PR DESCRIPTION
#### What does this PR do?
Include masters into etcd group, when it's empty

#### How should this be manually tested?
e2e manual testing

#### Is there a relevant Issue open for this?
Closes https://github.com/openshift/openshift-ansible-contrib/issues/558

#### Who would you like to review this?
cc: @tomassedovic PTAL
