### PR TITLE
Added prerequisity for python-openstackclient installation

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -12,6 +12,7 @@ etc.). The result is an environment ready for openshift-ansible.
 * [shade](https://pypi.python.org/pypi/shade)
 * python-dns / [dnspython](https://pypi.python.org/pypi/dnspython)
 * Become (sudo) is not required.
+* `rhel-7-server-openstack-10-rpms` repository (in order to be able to install `python-openstackclient`)
 
 ## Dependencies for OpenStack hosted cluster nodes (servers)
 

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -14,7 +14,7 @@ etc.). The result is an environment ready for openshift-ansible.
 * Become (sudo) is not required.
 * `rhel-7-server-openstack-10-rpms` repository (in order to be able to install `python-openstackclient`)
 
-### Optional Dependencies forlocalhost
+### Optional Dependencies for localhost
 **Note**: When using rhel images, `rhel-7-server-openstack-10-rpms` repository is required in order to install these packages.
 
 * `python-openstackclient`

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -14,6 +14,12 @@ etc.). The result is an environment ready for openshift-ansible.
 * Become (sudo) is not required.
 * `rhel-7-server-openstack-10-rpms` repository (in order to be able to install `python-openstackclient`)
 
+### Optional Dependencies forlocalhost
+**Note**: When using rhel images, `rhel-7-server-openstack-10-rpms` repository is required in order to install these packages.
+
+* `python-openstackclient`
+* `python-heatclient`
+
 ## Dependencies for OpenStack hosted cluster nodes (servers)
 
 There are no additional dependencies for the cluster nodes. Required

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -12,7 +12,6 @@ etc.). The result is an environment ready for openshift-ansible.
 * [shade](https://pypi.python.org/pypi/shade)
 * python-dns / [dnspython](https://pypi.python.org/pypi/dnspython)
 * Become (sudo) is not required.
-* `rhel-7-server-openstack-10-rpms` repository (in order to be able to install `python-openstackclient`)
 
 ### Optional Dependencies for localhost
 **Note**: When using rhel images, `rhel-7-server-openstack-10-rpms` repository is required in order to install these packages.


### PR DESCRIPTION
#### What does this PR do?
In README of openstack provisioning, prerequisity for python=openstackclient installation is added (rhel-7-server-openstack-10-rpms).

#### How should this be manually tested?
--

#### Is there a relevant Issue open for this?
Closes: #480 

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
