### PR TITLE
Set ansible_become for the OSEv3 group

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -181,7 +181,7 @@ file, this is how you stat the provisioning process:
 
 Once it succeeds, you can install openshift by running:
 
-    ansible-playbook --become --user openshift --private-key ~/.ssh/openshift -i inventory/ openshift-ansible/playbooks/byo/config.yml
+    ansible-playbook --user openshift --private-key ~/.ssh/openshift -i inventory/ openshift-ansible/playbooks/byo/config.yml
 
 
 ## License

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -19,3 +19,7 @@ openshift_override_hostname_check: true
 # For POCs or demo environments that are using smaller instances than
 # the official recommended values for RAM and DISK, uncomment the line below.
 #openshift_disable_check: disk_availability,memory_availability
+
+# NOTE(shadower): Always switch to root on the OSEv3 nodes.
+# openshift-ansible requires an explicit `become`.
+ansible_become: true


### PR DESCRIPTION
#### What does this PR do?

Because openshift-ansible requires root on the cluster nodes, but it
doesn't explicitly set it in the playbooks (like we do), let's set it
in our inventory instead of requiring to pass `--become` to
`ansible-playbook`.

That will simplify the installation steps as well as let us include
the provisioning and openshift-ansible playbooks in a single playbook.

#### How should this be manually tested?
Run end to end without passing `--become` to the openshift-ansible byo playbook (i.e. like it says in the readme now).

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @bogdando @Tlacenka  PTAL
