### PR TITLE
README: Added note about infra-ansible installation

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -39,8 +39,13 @@ Alternatively you can install directly from github:
     ansible-galaxy install git+https://github.com/redhat-cop/infra-ansible,master \
       -p openshift-ansible-contrib/roles
 
-Note, this assumes we're in the directory that contains the clonned
-openshift-ansible-contrib repo in its root path.
+Notes:
+* this assumes we're in the directory that contains the clonned 
+openshift-ansible-contrib repo in its root path
+* when trying to install a different version, the previous one must be removed
+(`infra-ansible` directory from [roles](https://github.com/openshift/openshift-ansible-contrib/tree/master/roles))
+because currently, even if there are differences between the two versions, the installation is skipped if
+any version exists
 
 ## What does it do
 

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -42,7 +42,7 @@ Alternatively you can install directly from github:
 Notes:
 * this assumes we're in the directory that contains the clonned 
 openshift-ansible-contrib repo in its root path
-* when trying to install a different version, the previous one must be removed
+* when trying to install a different version, the previous one must be removed first
 (`infra-ansible` directory from [roles](https://github.com/openshift/openshift-ansible-contrib/tree/master/roles))
 because currently, even if there are differences between the two versions, the installation is skipped if
 any version exists

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -40,12 +40,11 @@ Alternatively you can install directly from github:
       -p openshift-ansible-contrib/roles
 
 Notes:
-* this assumes we're in the directory that contains the clonned 
-openshift-ansible-contrib repo in its root path
-* when trying to install a different version, the previous one must be removed first
-(`infra-ansible` directory from [roles](https://github.com/openshift/openshift-ansible-contrib/tree/master/roles))
-because currently, even if there are differences between the two versions, the installation is skipped if
-any version exists
+* This assumes we're in the directory that contains the clonned 
+openshift-ansible-contrib repo in its root path.
+* When trying to install a different version, the previous one must be removed first
+(`infra-ansible` directory from [roles](https://github.com/openshift/openshift-ansible-contrib/tree/master/roles)).
+Otherwise, even if there are differences between the two versions, installation of the newer version is skipped.
 
 ## What does it do
 


### PR DESCRIPTION
#### What does this PR do?
Currently, when installing `infra-ansible` and some version of it already exists, this step is skipped. In order to install the newer version, the older one must be removed first. This should be mentioned in the provisioning README.

#### How should this be manually tested?
--

#### Is there a relevant Issue open for this?
--

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
