### PR TITLE
Set openshift_hostname explicitly for openstack

### DIFF
--- a/roles/static_inventory/templates/inventory.j2
+++ b/roles/static_inventory/templates/inventory.j2
@@ -12,6 +12,7 @@
 %} public_v4={{ hostvars[host]['public_v4'] }}{% endif %}
 {% if 'ansible_private_key_file' in hostvars[host]
 %} ansible_private_key_file={{ hostvars[host]['ansible_private_key_file'] }}{% endif %}
+ openshift_hostname={{ host }}
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
#### What does this PR do?

This fixes a regression caused by the move to the static inventory.
The nodes in `oc get nodes` should be (and had been) identified by
their hostnames (e.g. master-0.openshift.example.com), but are
now using their internal IP addresses instead.

#### How should this be manually tested?

Do end-to-end deployment, ssh to a master node as root and run `oc get nodes`. It should print the node hostnames, not IP addresses like so:

```
# oc get nodes
NAME                                STATUS                     AGE
app-node-0.openshift.example.com    Ready                      6m
infranode-0.openshift.example.com   Ready                      6m
master-0.openshift.example.com      Ready,SchedulingDisabled   6m
```

#### Is there a relevant Issue open for this?

Fixes #577

#### Who would you like to review this?
cc:  @bogdando @Tlacenka  PTAL
