### PR TITLE
Define openshift_hostname for cluster nodes FQDN

### DIFF
--- a/roles/static_inventory/tasks/openstack.yml
+++ b/roles/static_inventory/tasks/openstack.yml
@@ -31,6 +31,7 @@
         groups: '{{ item.metadata.group }}'
         ansible_host: '{{ item.private_v4 }}'
         ansible_fqdn: '{{ item.name }}'
+        openshift_hostname: '{{ item.name }}'
         ansible_private_key_file: '{{ private_ssh_key }}'
         private_v4: '{{ item.private_v4 }}'
 
@@ -42,6 +43,7 @@
         groups: '{{ item.metadata.group }}'
         ansible_host: '{{ item.public_v4 }}'
         ansible_fqdn: '{{ item.name }}'
+        openshift_hostname: '{{ item.name }}'
         ansible_private_key_file: '{{ private_ssh_key }}'
         private_v4: '{{ item.private_v4 }}'
         public_v4: '{{ item.public_v4 }}'

--- a/roles/static_inventory/templates/inventory.j2
+++ b/roles/static_inventory/templates/inventory.j2
@@ -12,6 +12,8 @@
 %} public_v4={{ hostvars[host]['public_v4'] }}{% endif %}
 {% if 'ansible_private_key_file' in hostvars[host]
 %} ansible_private_key_file={{ hostvars[host]['ansible_private_key_file'] }}{% endif %}
+{% if 'openshift_hostname' in hostvars[host]
+%} openshift_hostname={{ hostvars[host]['openshift_hostname'] }}{% endif %}
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
#### What does this PR do?
Make oc get nodes to report FQDNs for nodes instead of IPs.

#### How should this be manually tested?
Deploy the cluster, check the `oc get nodes` results to contain FQDNs of the cluster hosts

#### Is there a relevant Issue open for this?
Closes https://github.com/openshift/openshift-ansible-contrib/issues/577

#### Who would you like to review this?
cc: @tomassedovic @Tlacenka  PTAL
