### PR TITLE
Fixed incorrect value to htpasswd_users

### DIFF
--- a/reference-architecture/rhv-ansible/ocp-vars.yaml
+++ b/reference-architecture/rhv-ansible/ocp-vars.yaml
@@ -69,8 +69,7 @@ openshift_master_identity_providers:
 #  - user2: <pre-hashed password>
 # Use 'htpasswd -n <user>' to generate password hash. (htpasswd from httpd-tools RPM)
 # Example with admin:changeme
-openshift_master_htpasswd_users:
-  - admin: '$apr1$zAhyA9Ko$rBxBOwAwwtRuuaw8OtCwH0'
+openshift_master_htpasswd_users: {'admin': '$apr1$zAhyA9Ko$rBxBOwAwwtRuuaw8OtCwH0'}
 # or
 #openshift_master_htpasswd_file=<path to local pre-generated htpasswd file>
 


### PR DESCRIPTION
#### What does this PR do?
Fixes the ocp-vars.yaml example 

#### How should this be manually tested?
Fill in rest of values in ocp-vars and install through openshift-install.yaml playbook

#### Is there a relevant Issue open for this?
Found in own testing.

#### Who would you like to review this?
cc: @cooktheryan @e-minguez 