### PR TITLE
Fix syntax error when running gcloud.sh script multiple times

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/roles/deployment-create/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/deployment-create/tasks/main.yaml
@@ -6,7 +6,7 @@
   register: deployment_config_from_template
 
 - name: check if deployment {{ deployment_name_with_prefix }} exists
-  command: gcloud --project {{ gcloud_project }} deployment-manager deployments describe {{ deployment_name_with_prefix }}
+  command: gcloud --project {{ gcloud_project }} deployment-manager deployments describe {{ deployment_name_with_prefix }} --format 'yaml(deployment.operation)'
   register: deployment_exists
   changed_when: false
   ignore_errors: true
@@ -16,11 +16,11 @@
     name: deployment-delete
   when:
   - deployment_exists | succeeded
-  - (deployment_exists.stdout | from_yaml).operation.error is defined
+  - (deployment_exists.stdout | from_yaml).deployment.operation.error is defined
 
 - name: create deployment {{ deployment_name_with_prefix }}
   command: gcloud --project {{ gcloud_project }} deployment-manager deployments create {{ deployment_name_with_prefix }} --config '{{ deployment_config }}'
-  when: deployment_exists | failed or (deployment_exists.stdout | from_yaml).operation.error is defined
+  when: deployment_exists | failed or (deployment_exists.stdout | from_yaml).deployment.operation.error is defined
 
 - name: update deployment {{ deployment_name_with_prefix }}
   command: gcloud --project {{ gcloud_project }} deployment-manager deployments update {{ deployment_name_with_prefix }} --config '{{ deployment_config }}'

--- a/reference-architecture/gce-cli/ansible/playbooks/roles/wait-for-instance-group/tasks/main.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/roles/wait-for-instance-group/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: wait until the instance group {{ instance_group }} is ready
-  command: gcloud --project {{ gcloud_project }} compute instance-groups managed describe {{ instance_group }} --region {{ gcloud_region }} --format='yaml(targetSize, currentActions.none)'
+  command: gcloud --project {{ gcloud_project }} compute instance-groups managed describe {{ instance_group }} --region {{ gcloud_region }} --format 'yaml(targetSize, currentActions.none)'
   register: instance_group_size_and_action_none
   until: (instance_group_size_and_action_none.stdout | from_yaml).targetSize == (instance_group_size_and_action_none.stdout | from_yaml).currentActions.none
   retries: 20


### PR DESCRIPTION
#### What does this PR do?
Fix syntax error when running gcloud.sh script multiple times.

#### How should this be manually tested?
Try to run `gcloud.sh` script twice in a row.

#### Is there a relevant Issue open for this?
Resolves #566

#### Who would you like to review this?
cc: @e-minguez @cooktheryan PTAL