### PR TITLE
Add wildcard record for Private DNS

### DIFF
--- a/playbooks/provisioning/openstack/openstack_dns_records.yml
+++ b/playbooks/provisioning/openstack/openstack_dns_records.yml
@@ -6,7 +6,7 @@
 
 - name: "Add wildcard records to the private A records for infrahosts"
   set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_app_domain, 'ip': hostvars[item]['openstack']['private_v4'] } ] }}"
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_app_domain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['infra_hosts'] }}"
 
 - name: "Set the private DNS server to use the external value (if provided)"

--- a/playbooks/provisioning/openstack/openstack_dns_records.yml
+++ b/playbooks/provisioning/openstack/openstack_dns_records.yml
@@ -4,6 +4,11 @@
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[item]['ansible_hostname'], 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
 
+- name: "Add wildcard records to the private A records for infrahosts"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_app_domain, 'ip': hostvars[item]['openstack']['private_v4'] } ] }}"
+  with_items: "{{ groups['infra_hosts'] }}"
+
 - name: "Set the private DNS server to use the external value (if provided)"
   set_fact:
     nsupdate_server_private: "{{ external_nsupdate_keys['private']['server'] }}"


### PR DESCRIPTION
#### What does this PR do?
Double delivery of casl-ansible PR
Adds the DNS wildcard to the private DNS view

#### How should this be manually tested?
From the app-0 VM instance execute: dig @<private IP of dns vm> <env_id.dns_domain> axfr
verify: *.apps.<dns_domain> is pointing to IP of infranode

#### Is there a relevant Issue open for this?
This was delivered to casl-ansible raised issue

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL @oybed 
