### PR TITLE
fix storage class removal

### DIFF
--- a/reference-architecture/vmware-ansible/playbooks/roles/heketi-ocp-clean/tasks/main.yaml
+++ b/reference-architecture/vmware-ansible/playbooks/roles/heketi-ocp-clean/tasks/main.yaml
@@ -10,10 +10,6 @@
   command: "oc get storageclass"
   register: storage_class
 
-- name: Remove heketi secret from OCP
-  command: "oc delete secret heketi-secret"
-  when: "'heketi-secret' in oc_secrets.stdout"
-
 - name: Remove storage class from OCP
-  command: "oc delete storageclass crs-slow-st1"
-  when: "'crs-slow-st1' in storage_class.stdout"
+  command: "oc delete storageclass crs-gluster"
+  when: "'crs-gluster' in storage_class.stdout"


### PR DESCRIPTION
#### What does this PR do?
Properly cleans the storage class up and skips deleting the heketi secrets

#### How should this be manually tested?
add-node.py --tag clean --node_type=storage
the ocp-on-vmware.ini file should include

container_storage=crs


#### Who would you like to review this?
cc: @cooktheryan  @rlopez133  PTAL
