### PR TITLE
Adding meta info for galaxy consumption of this repo

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,2 @@
 ---
 dependencies:
-


### PR DESCRIPTION
#### What does this PR do?
Adding the `meta/main.yml` file to allow for ansible-galaxy consumption of this repo. 

#### How should this be manually tested?
Change over to the target directory, and create a file called `requirements.yml` with the following content:

```
- src: https://github.com/openshift/openshift-ansible-contrib
```

... or when testing this PR, use the following:
```
- src: https://github.com/oybed/openshift-ansible-contrib
  version: add-meta
```
Then run:
```
>> ansible-galaxy install -r requirements.yml -p roles
```
Validate that there are no errors, and that the `openshift-ansible-contrib` content exists within the `roles` directory. 

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic @bogdando
