### PR TITLE
Support scaling up for masters and nodes

### DIFF
--- a/reference-architecture/gce-cli/ansible/playbooks/openshift-scaleup.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/openshift-scaleup.yaml
@@ -1,4 +1,38 @@
 ---
+- name: verify current and desired state
+  hosts: localhost
+  tasks:
+  - name: get current number of master nodes
+    command: gcloud --project {{ gcloud_project }} compute instance-groups managed describe {{ prefix }}-master --region {{ gcloud_region }} --format 'value(targetSize)'
+    register: masters_nb
+    changed_when: false
+
+  - name: get current number of infra nodes
+    command: gcloud --project {{ gcloud_project }} compute instance-groups managed describe {{ prefix }}-infra-node --region {{ gcloud_region }} --format 'value(targetSize)'
+    register: infra_nodes_nb
+    changed_when: false
+
+  - name: get current number of app nodes
+    command: gcloud --project {{ gcloud_project }} compute instance-groups managed describe {{ prefix }}-node --region {{ gcloud_region }} --format 'value(targetSize)'
+    register: nodes_nb
+    changed_when: false
+
+  - name: assert that we are not scaling down
+    assert:
+      that:
+      - "master_instance_group_size >= masters_nb.stdout | int"
+      - "infra_node_instance_group_size >= infra_nodes_nb.stdout | int"
+      - "node_instance_group_size >= nodes_nb.stdout | int"
+      msg: Scaling down is not supported! Desired number of nodes must be equal or bigger than the current state.
+
+  - name: verify that there is something to scale up
+    fail:
+      msg: To scale up, update 'master_instance_group_size', 'infra_node_instance_group_size' and 'node_instance_group_size' variables to the desired number of nodes in your 'config.yaml' file and rerun this command.
+    when:
+    - master_instance_group_size == masters_nb.stdout | int
+    - infra_node_instance_group_size == infra_nodes_nb.stdout | int
+    - node_instance_group_size == nodes_nb.stdout | int
+
 - include: core-infra.yaml
 
 - name: create instance groups

--- a/reference-architecture/gce-cli/ansible/playbooks/openshift-scaleup.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/openshift-scaleup.yaml
@@ -1,4 +1,6 @@
 ---
+- include: core-infra.yaml
+
 - name: create instance groups
   hosts: localhost
   roles:

--- a/reference-architecture/gce-cli/ansible/playbooks/openshift-scaleup.yaml
+++ b/reference-architecture/gce-cli/ansible/playbooks/openshift-scaleup.yaml
@@ -1,0 +1,9 @@
+---
+- name: create instance groups
+  hosts: localhost
+  roles:
+  - instance-groups
+
+- include: ../../../../../openshift-ansible/playbooks/byo/openshift_facts.yml
+- include: ../../../../../openshift-ansible/playbooks/byo/openshift-master/scaleup.yml
+- include: ../../../../../openshift-ansible/playbooks/byo/openshift-node/scaleup.yml

--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -47,7 +47,6 @@ function run_playbook {
 
 # Scale up infrastructure and OCP
 function scaleup {
-  run_playbook playbooks/core-infra.yaml "$@"
   run_playbook playbooks/openshift-scaleup.yaml "$@"
 }
 

--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -45,6 +45,12 @@ function run_playbook {
   popd
 }
 
+# Scale up infrastructure and OCP
+function scaleup {
+  run_playbook playbooks/core-infra.yaml "$@"
+  run_playbook playbooks/openshift-scaleup.yaml "$@"
+}
+
 # Teardown infrastructure
 function teardown {
   run_playbook playbooks/teardown.yaml "$@"
@@ -62,6 +68,11 @@ function main {
 }
 
 case ${1:-} in
+  --scaleup )
+    shift
+    scaleup "$@"
+    exit 0
+    ;;
   --teardown | --revert )
     shift
     teardown "$@"


### PR DESCRIPTION
#### What does this PR do?
Enable scaling up of OCP cluster. To use it, update your `config.yaml` file with new number of required nodes (must be bigger than before, scaling down is not supported), and run `gcloud.sh --scaleup` command.

#### How should this be manually tested?
Try to scale up existing OCP deployment.

#### Is there a relevant Issue open for this?
Original PR #506 
Resolves #567 

#### Who would you like to review this?
cc: @bdurrow @cooktheryan PTAL