### PR TITLE
Unregister VMs before destroying them

### DIFF
--- a/reference-architecture/rhv-ansible/playbooks/ovirt-vm-uninstall.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/ovirt-vm-uninstall.yaml
@@ -1,4 +1,13 @@
 ---
+- name: Unregister VMs
+  hosts:
+    - tag_openshift_masters
+    - tag_openshift_infra
+    - tag_openshift_node
+    - tag_openshift_lb
+  roles:
+    - rhsm-unregister
+
 - name: oVirt infra destroy
   hosts: engine
   connection: local


### PR DESCRIPTION
#### What does this PR do?
Adds code to unregister openshift cluster VMs before destroying them with ovirt-ansible code.

#### How should this be manually tested?
Create VMs in RHV using ovirt-vm-infra,
subscribe them with openshift-install.yaml,
run openshift-uninstall.yaml playbook

#### Is there a relevant Issue open for this?
Bringing code up to match other providers

#### Who would you like to review this?
cc: @cooktheryan @e-minguez 