### PR TITLE
Bugfixes to ref.arch./ocp-dns

### DIFF
--- a/reference-architecture/osp-dns/deploy-dns.yaml
+++ b/reference-architecture/osp-dns/deploy-dns.yaml
@@ -105,7 +105,7 @@
       server_hostname: "{{ sat6_hostname|default(None) }}"
       org_id: "{{ sat6_organization|default(None) }}"
       activationkey: "{{ sat6_activationkey|default(None) }}"
-    when: rhn_username|default and rhn_password|default and rhn_pool|default == ""
+    when: rhn_username|default or sat6_hostname|default
 
   - name: Subscribe to RHN and attach a pool
     redhat_subscription:
@@ -115,6 +115,6 @@
       server_hostname: "{{ sat6_hostname|default(None) }}"
       org_id: "{{ sat6_organization|default(None) }}"
       activationkey: "{{ sat6_activationkey|default(None) }}"
-    when: rhn_username|default and rhn_password|default and rhn_pool|default
+    when: rhn_username|default or sat6_hostname|default
 
 - include: ansible/bind-server.yml

--- a/reference-architecture/osp-dns/heat/fragments/rhn-register.sh
+++ b/reference-architecture/osp-dns/heat/fragments/rhn-register.sh
@@ -15,7 +15,7 @@ RHN_USERNAME=${RHN_USERNAME:-'{{rhn_username}}'}
 RHN_PASSWORD=${RHN_PASSWORD:-'{{rhn_password}}'}
 RHN_POOL_ID=${RHN_POOL_ID:-'{{rhn_pool_id}}'}
 SAT6_HOSTNAME=${SAT6_HOSTNAME:-'{{sat6_hostname}}'}
-SAT6_ORGANIZATION=${SAT6_ORGANIZATION:-'{{sat6_hostname}}'}
+SAT6_ORGANIZATION=${SAT6_ORGANIZATION:-'{{sat6_organization}}'}
 SAT6_ACTIVATIONKEY=${SAT6_ACTIVATIONKEY:-'{{sat6_activationkey}}'}
 
 # Exit on command fail


### PR DESCRIPTION

#### What does this PR do?
As a Red Hat Consultant i've tried this out together with one of our customers.
This fixes some bugs found during testing/deployment.

1) sat6_organization != sat6_hostname. 

2) In our use-case we only specify Satellite activationkey, no username/password necessary, so don't check for that in your condition

#### How should this be manually tested?
cat >vars.yaml
sat6_hostname: "satellite.corp"
sat6_organization: "myorg"
sat6_activationkey: "openshift"

ansible-playbook deploy-dns.yaml -e @vars.yaml

#### Is there a relevant Issue open for this?
This PR!

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
