### PR TITLE
Updated the default openshift-sdn option to match the default in the …

### DIFF
--- a/reference-architecture/aws-ansible/add-cns-storage.py
+++ b/reference-architecture/aws-ansible/add-cns-storage.py
@@ -12,7 +12,7 @@ import sys
               show_default=True)
 @click.option('--deployment-type', default='openshift-enterprise', help='OpenShift deployment type',
               show_default=True)
-@click.option('--openshift-sdn', default='redhat/openshift-ovs-subnet', type=click.Choice(['redhat/openshift-ovs-subnet', 'redhat/openshift-ovs-multitenant']),  help='OpenShift SDN',
+@click.option('--openshift-sdn', default='redhat/openshift-ovs-multitenant', type=click.Choice(['redhat/openshift-ovs-subnet', 'redhat/openshift-ovs-multitenant']),  help='OpenShift SDN',
               show_default=True)
 
 ### AWS/EC2 options

--- a/reference-architecture/aws-ansible/add-node.py
+++ b/reference-architecture/aws-ansible/add-node.py
@@ -12,7 +12,7 @@ import sys
               show_default=True)
 @click.option('--deployment-type', default='openshift-enterprise', help='OpenShift deployment type',
               show_default=True)
-@click.option('--openshift-sdn', default='redhat/openshift-ovs-subnet', help='OpenShift SDN (redhat/openshift-ovs-subnet, redhat/openshift-ovs-multitenant, or other supported SDN)',
+@click.option('--openshift-sdn', default='redhat/openshift-ovs-multitenant', help='OpenShift SDN (redhat/openshift-ovs-subnet, redhat/openshift-ovs-multitenant, or other supported SDN)',
               show_default=True)
 
 ### AWS/EC2 options


### PR DESCRIPTION
…ose-on-aws.py installer

#### What does this PR do?
Change to the defaults for the --openshift-sdn parameter within add-node.py and add-cns-storage.py to match the default in ose-on-aws.py. 

The default in ose-on-aws.py is 'redhat/openshift-ovs-multitenant' so adding a node would fail if you didn't specifically set the --openshift-sdn parameter.

#### How should this be manually tested?

Install using ose-on-aws.py not setting --openshift-sdn so using default
Add a node using the add-node.py not setting --openshift-sdn so using default
Verify node is added and working correctly

#### Is there a relevant Issue open for this?
Nope

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
