### PR TITLE
Removing confusing old hostfile entry

### DIFF
--- a/reference-architecture/rhv-ansible/ansible.cfg
+++ b/reference-architecture/rhv-ansible/ansible.cfg
@@ -1,9 +1,8 @@
 [defaults]
 forks = 50
 host_key_checking = False
-#hostfile = inventory/rhv/vms/rhv_inventory.py
 hostfile = inventory/
-inventory_ignore_extensions = .example, .ini, .pyc
+inventory_ignore_extensions = .example, .ini, .pyc, .pem
 gathering = smart
 # Roles path assumes this repo is checked out to same directory as
 # https://github.com/oVirt/ovirt-ansible.git


### PR DESCRIPTION
Also adding .pem as an ignored extension in case user puts the ca.pem in the inventory directory :-)

#### What does this PR do?
  * Clears an old, commented-out hostfile entry
  * Adds `.pem` as an ignored extension

#### How should this be manually tested?
Run ansible all --list-hosts

#### Is there a relevant Issue open for this?
Found in review

#### Who would you like to review this?
cc: @cooktheryan @e-minguez @dav1x 
