### PR TITLE
Allow using ephemeral volumes for docker storage

### DIFF
--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -78,3 +78,8 @@ ansible_user: openshift
 #openstack_private_ssh_key: ~/.ssh/openshift
 # # The path for the SSH config to access all nodes
 #openstack_ssh_config_path: /tmp/ssh.config.openshift.ansible.{{ env_id }}.{{ public_dns_domain }}
+
+
+# If you want to use the VM storage instead of Cinder volumes, set this to `true`.
+# NOTE: this is for testing only! Your data will be gone once the VM disappears!
+# ephemeral_volumes: false

--- a/roles/openstack-stack/templates/heat_stack_server.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server.yaml.j2
@@ -156,6 +156,7 @@ resources:
       floating_network: { get_param: floating_network }
       port_id: { get_resource: port }
 
+{% if not ephemeral_volumes|default(false)|bool %}
   cinder_volume:
     type: OS::Cinder::Volume
     properties:
@@ -168,3 +169,4 @@ resources:
       volume_id: { get_resource: cinder_volume }
       instance_uuid: { get_resource: server }
       mountpoint: /dev/sdb
+{% endif %}

--- a/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
@@ -135,6 +135,7 @@ resources:
         - subnet: { get_param: subnet }
       security_groups: { get_param: secgrp }
 
+{% if not ephemeral_volumes|default(false)|bool %}
   cinder_volume:
     type: OS::Cinder::Volume
     properties:
@@ -147,3 +148,4 @@ resources:
       volume_id: { get_resource: cinder_volume }
       instance_uuid: { get_resource: server_nofloating }
       mountpoint: /dev/sdb
+{% endif %}


### PR DESCRIPTION
#### What does this PR do?

For testing cases it's sometimes useful to not create Cinder volumes for
the VMs. It can also sometimes be a little faster and more robust (but
unfit for production).

This adds an option called `ephemeral_volumes` that will use the VM's
storage instead of creating volumes when set to true.

#### How should this be manually tested?
Put `ephemeral_volumes: true` in your `group_vars/all.yml` and run an end to end deployment. Verify that no Cinder volumes are created.

If `ephemeral_volumes` is not specified, nothing should change (i.e. we create the cinder volumes as usual).


#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc:  @bogdando @Tlacenka @tzumainn  PTAL
