### PR TITLE
Remove clouds.yaml from sample-inventory

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -63,10 +63,6 @@ Otherwise, even if there are differences between the two versions, installation 
 
     cp -r openshift-ansible-contrib/playbooks/provisioning/openstack/sample-inventory inventory
 
-### Copy clouds.yaml
-
-    cp openshift-ansible-contrib/playbooks/provisioning/openstack/sample-inventory/clouds.yaml clouds.yaml
-
 ### Copy ansible config
 
     cp openshift-ansible-contrib/playbooks/provisioning/openstack/sample-inventory/ansible.cfg ansible.cfg

--- a/playbooks/provisioning/openstack/sample-inventory/clouds.yaml
+++ b/playbooks/provisioning/openstack/sample-inventory/clouds.yaml
@@ -1,5 +1,0 @@
----
-ansible:
-  use_hostnames: True
-  expand_hostvars: True
-  fail_on_errors: True


### PR DESCRIPTION
#### What does this PR do?

With the move to the static inventory, we don't need it anymore so it's
now just an unnecessary step in the deployment.

Note that the users may still want to use clouds.yaml for openstack
credentials instead of sourcing the `OS_*` environment variables, but
they can do that at their discression.

The reason we had the clouds.yaml here was because the `openstack.py`
dynamic inventory used the servers' UUID's as ansible hosts by default
and the options we put in caused it to use the hostnames (as desired).

#### How should this be manually tested?
Remove the clouds.yaml file from the directory you're running ansible from. Then do an end-end deployment. Everything should still work.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @Tlacenka @tzumainn  @bogdando PTAL
