### PR TITLE
Default storage domain changed to a variable

### DIFF
--- a/reference-architecture/rhv-ansible/ocp-vars.yaml
+++ b/reference-architecture/rhv-ansible/ocp-vars.yaml
@@ -18,6 +18,9 @@ qcow_url:
 # Name of cluster to install on
 rhv_cluster: Default
 
+# Name of RHV storage domain to create disks
+rhv_data_storage: my_data_storage
+
 ### Choose a subscription method:
 ## For subscriptions to Satellite:
 #

--- a/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
@@ -159,11 +159,11 @@ master_vm:
   disks:
     - size: 40GiB
       name: docker_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
     - size: 40GiB
       name: etcd_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
 
 node_vm:
@@ -176,11 +176,11 @@ node_vm:
   disks:
     - size: 20GiB
       name: docker_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
     - size: 15GiB
       name: localvol_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
 
 infra_vm:
@@ -194,11 +194,11 @@ infra_vm:
   disks:
     - size: 20GiB
       name: docker_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
     - size: 15GiB
       name: localvol_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
 
 lb_vm:
@@ -212,11 +212,11 @@ lb_vm:
   disks:
     - size: 20GiB
       name: docker_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
     - size: 15GiB
       name: localvol_disk
-      storage_domain: my_data_storage
+      storage_domain: "{{ rhv_data_storage }}"
       interface: virtio
 
 vms:


### PR DESCRIPTION
#### What does this PR do?
Storage domain in RHV vm setup is now a variable (was hard-coded)
Variable definition added to `ocp-vars.yaml` file 

#### How should this be manually tested?
Run the `ovirt-vm-infra.yaml` playbook as defined in refarch

#### Is there a relevant Issue open for this?
Found in review.

#### Who would you like to review this?
cc: @cooktheryan 