### PR TITLE
Create and assign a log file for ansible runs

### DIFF
--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -31,6 +31,9 @@ set -euo pipefail
 # Directory of this script
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Create and assign log file for ansible
+export ANSIBLE_LOG_PATH=${DIR}/$(mktemp -p . ansible-$(date -I)-XXXXXXX.log)
+
 # Our config file
 CONFIG_FILE='../config.yaml'
 


### PR DESCRIPTION
#### What does this PR do?
This change creates a log file for ansible logs.
It uses date to easily identify the date run and a random set of characters, with mktemp, to avoid having it overwritten when running several times 

#### How should this be manually tested?
Run a new deployment and find your created logfile.

#### Is there a relevant Issue open for this?
When having issues while deploying OpenShift, as in quota limits in GCP, problems registering machines, etc ... it makes it easier to debug and detect what was the root cause.

#### Who would you like to review this?
cc: @pschiffe 
