### PR TITLE
Add --redeploy and --clear-logs options to gcloud.sh

### DIFF
--- a/reference-architecture/gce-cli/.gitignore
+++ b/reference-architecture/gce-cli/.gitignore
@@ -2,3 +2,5 @@ config.yaml
 project.json
 secrets.py
 .ansible
+ansible-*.log
+

--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -46,7 +46,7 @@ ANSIBLE_LOG_PATH="${DIR}/ansible-$(date +%F_%T).log"
 export ANSIBLE_LOG_PATH
 
 function display_help {
-  echo "./$(basename "$0") [ -c | --config FILE ] [ -q | --quiet ] [ -h | --help | --teardown | --static-inventory | --scaleup | --prereq | --gold-image | --infra | --clear-logs ] [ OPTIONAL ANSIBLE OPTIONS ]
+  echo "./$(basename "$0") [ -c | --config FILE ] [ -q | --quiet ] [ -h | --help | --teardown | --redeploy | --static-inventory | --scaleup | --prereq | --gold-image | --infra | --clear-logs ] [ OPTIONAL ANSIBLE OPTIONS ]
 
 Helper script to deploy infrastructure and OpenShift on Google Cloud Platform
 
@@ -55,8 +55,10 @@ Where:
                       to the 'ansible' directory. Default is '../config.yaml'
   -q | --quiet        Don't ask for confirmations
   -h | --help         Display this help text
-  --teardown          Teardown the OpenShift and infrastructure.
+  --teardown          Teardown the OpenShift and the infrastructure.
                       Warning: you will loose all your data
+  --redeploy          Teardown the OpenShift and the infrastructure and deploy
+                      it again. Warning: you will loose all your data
   --static-inventory  Generate static Ansible inventory file for existing infra.
                       It will be saved as 'ansible/static-inventory'
   --scaleup           Scale up your OpenShift deployment. Update your
@@ -128,6 +130,7 @@ function scaleup {
 
 # Teardown infrastructure
 function teardown {
+  ask_for_confirmation 'Are you sure you want to destroy OpenShift and the infrastructure? You will loose all your data.'
   run_playbook playbooks/teardown.yaml "$@"
 }
 
@@ -179,8 +182,13 @@ while true; do
       ;;
     --teardown | --revert )
       shift
-      ask_for_confirmation 'Are you sure you want to destroy OpenShift and the infrastructure? You will loose all your data.'
       teardown "$@"
+      exit 0
+      ;;
+    --redeploy )
+      shift
+      teardown "$@"
+      main "$@"
       exit 0
       ;;
     --static-inventory )

--- a/reference-architecture/gce-cli/gcloud.sh
+++ b/reference-architecture/gce-cli/gcloud.sh
@@ -31,9 +31,6 @@ set -euo pipefail
 # Directory of this script
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Create and assign log file for ansible
-export ANSIBLE_LOG_PATH=${DIR}/$(mktemp -p . ansible-$(date -I)-XXXXXXX.log)
-
 # Our config file
 CONFIG_FILE='../config.yaml'
 
@@ -44,8 +41,12 @@ QUIET=0
 PYTHONPATH="${PYTHONPATH:-}:${DIR}/ansible/inventory/gce/hosts"
 export PYTHONPATH
 
+# Assign log file for ansible
+ANSIBLE_LOG_PATH="${DIR}/ansible-$(date +%F_%T).log"
+export ANSIBLE_LOG_PATH
+
 function display_help {
-  echo "./$(basename "$0") [ -c | --config FILE ] [ -q | --quiet ] [ -h | --help | --teardown | --static-inventory | --scaleup | --prereq | --gold-image | --infra ] [ OPTIONAL ANSIBLE OPTIONS ]
+  echo "./$(basename "$0") [ -c | --config FILE ] [ -q | --quiet ] [ -h | --help | --teardown | --static-inventory | --scaleup | --prereq | --gold-image | --infra | --clear-logs ] [ OPTIONAL ANSIBLE OPTIONS ]
 
 Helper script to deploy infrastructure and OpenShift on Google Cloud Platform
 
@@ -66,6 +67,7 @@ Where:
                       to the GCP, DNS zone, runs validation tests, etc.
   --gold-image        Run prerequisite playbook and create gold image in GCP
   --infra             Create complete infrastructure without deploying OpenShift
+  --clear-logs        Delete all Ansible logs created by this script
 
 If no action option is specified, the script will create the infrastructure
 and deploy OpenShift on top of it.
@@ -184,6 +186,10 @@ while true; do
     --static-inventory )
       shift
       static_inventory "$@"
+      exit 0
+      ;;
+    --clear-logs )
+      rm -f "${DIR}"/ansible-*.log
       exit 0
       ;;
     * )


### PR DESCRIPTION
#### What does this PR do?
Add --redeploy and --clear-logs options to gcloud.sh, slightly modify ansible log file creation

#### How should this be manually tested?
Verify that after deployment ansible log file is created, it can be removed with --clear-logs and that --redeploy option teardowns the whole infra and redeploys openshift

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @mperezco PTAL
