### PR TITLE
fix to allow for origin to be installed on rhel

### DIFF
--- a/playbooks/aws-prerequisite.yaml
+++ b/playbooks/aws-prerequisite.yaml
@@ -4,13 +4,17 @@
   become: yes
   serial: 1
   roles:
-  - aws-rhsm-subscription
+  - role: aws-rhsm-subscription
+    when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
+          ansible_distribution == "RedHat" and rhel_subscription_user is not defined
 
 - hosts: cluster_hosts
   gather_facts: no
   become: yes
   roles:
-  - rhsm-repos
+  - role: rhsm-repos
+    when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
+          ansible_distribution == "RedHat" and rhel_subscription_user is not defined
   - prerequisites
 
 - hosts: master


### PR DESCRIPTION
#### What does this PR do?
Allow for Origin to be installed on RHEL

#### How should this be manually tested?
[root@trunks aws-ansible]# ./ose-on-aws.py --public-hosted-zone=ci.sysdeseng.com --deployment-type=origin --ami=ami-ebba9e90 --keypair=OSE-key --github-client-id=3a90715d36470ad14a9c --github-organization=openshift --github-client-secret=47a0c61f7095b351839675ed78aecfb7876925f9 --stack-name=threesix --openshift-sdn=redhat/openshift-ovs-multitenant  --containerized=true


#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @rlopez133 @dav1x 


Resolves part of #633 