### PR TITLE
Disable the openshift_version default group var

### DIFF
--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -1,6 +1,7 @@
 ---
 openshift_deployment_type: origin
-openshift_release: 1.5.1
+#TODO(bogdando) uncomment the openshift_release once we figured out the version
+#openshift_release: 1.5.1
 #openshift_deployment_type: openshift-enterprise
 #openshift_release: v3.5
 openshift_master_default_subdomain: "apps.{{ env_id }}.{{ public_dns_domain }}"


### PR DESCRIPTION
#### What does this PR do?
The given default value no longer works with the error msg:
"You requested openshift_release 1.5.1, which is not matched by the latest OpenShift RPM we detected as origin-3.6.0..."

#### How should this be manually tested?
e2e

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic PTAL
