### PR TITLE
Avoid server recreation in case of user_data modification.

### DIFF
--- a/roles/openstack-stack/templates/heat_stack_server.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server.yaml.j2
@@ -134,6 +134,7 @@ resources:
       user_data:
         get_file: user-data
       user_data_format: RAW
+      user_data_update_policy: IGNORE
       metadata:
         group: { get_param: group }
         environment: { get_param: cluster_env }

--- a/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
@@ -119,6 +119,7 @@ resources:
       user_data:
         get_file: user-data
       user_data_format: RAW
+      user_data_update_policy: IGNORE
       metadata:
         group: { get_param: group }
         environment: { get_param: cluster_env }


### PR DESCRIPTION
#### What does this PR do?
Avoid that changes in user_data triggers server recreation via stack update.

#### How should this be manually tested?
1- modify any parameter involved in the generation of user_data
2- run the playbook that trigger the stack update

#### Is there a relevant Issue open for this?
Similar to this one
https://github.com/redhat-openstack/openshift-on-openstack/issues/360
Related https://github.com/openshift/openshift-ansible-contrib/issues/533

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
