### PR TITLE
Support proxy in subscription-manager

### DIFF
--- a/roles/subscription-manager/README.md
+++ b/roles/subscription-manager/README.md
@@ -10,6 +10,17 @@ Subscription Manager server hostname. If using a Satellite server set the FQDN h
 
 Default: none
 
+### rhsm_config_options
+
+Subscription Manager configuration options. If using a subscription-manager via an http proxy.
+
+
+    ```
+    rhsm_config_options: "--server.proxy_hostname=squid.example.com --server.proxy_port=3128" 
+
+    ```
+Default: none
+
 ### rhsm_username
 
 Subscription Manager username. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use **rhsm_activationkey** for this.

--- a/roles/subscription-manager/tasks/main.yml
+++ b/roles/subscription-manager/tasks/main.yml
@@ -38,6 +38,7 @@
 
 - name: "Checking subscription status (a failure means it is not registered and will be)"
   command: "/usr/bin/subscription-manager status"
+  check_mode: no
   ignore_errors: yes
   changed_when: no
   register: check_if_registered
@@ -64,6 +65,13 @@
     - rhsm_satellite is defined
     - rhsm_satellite is not none
     - rhsm_satellite|trim != ''
+
+- name: "Set configuration options for subscription manager (eg. --server.proxy_hostname, --server.proxy_port)"
+  command: "/usr/bin/subscription-manager config {{rhsm_config_options}}"
+  when:
+    - rhsm_config_options is defined
+    - rhsm_config_options is not none
+    - rhsm_config_options|trim != ''
 
 - name: "Register to Satellite using activation key"
   command: "/usr/bin/subscription-manager register --activationkey={{ rhsm_activationkey }} --org='{{ rhsm_org }}'"


### PR DESCRIPTION
#### What does this PR do?
Enables:

 -  connecting RHSM via http/s proxy.
 -  fixes the inability to run this role in --check mode 

#### How should this be manually tested?
Set a reference to a local proxy in rhsm_config_options
```
rhsm_config_options: --server.proxy_hostname=squid.example.com --server.proxy_port=3128
```

#### Is there a relevant Issue open for this?
https://github.com/redhat-openstack/openshift-on-openstack/issues/339

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
