### PR TITLE
Download the oc binary from the master node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ python:
 env:
   global:
     - CI_CONCURRENT_JOBS=1
+    - OPENSHIFT_ANSIBLE_COMMIT=master
   matrix:
     - RUN_OPENSTACK_CI=false
     - RUN_OPENSTACK_CI=true

--- a/ci/openstack/install.sh
+++ b/ci/openstack/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 source ci/openstack/vars.sh
 if [ "${RUN_OPENSTACK_CI:-}" != "true" ]; then
@@ -15,11 +15,7 @@ fi
 
 git clone https://github.com/openshift/openshift-ansible ../openshift-ansible
 cd ../openshift-ansible
-git checkout openshift-ansible-3.6.153-1
+git checkout "${OPENSHIFT_ANSIBLE_COMMIT:-master}"
 cd ../openshift-ansible-contrib
 
 pip install ansible shade dnspython python-openstackclient python-heatclient
-
-curl -L -o oc.tgz https://github.com/openshift/origin/releases/download/v1.5.1/openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit.tar.gz
-tar -xf oc.tgz
-mv openshift-origin-client-tools-v1.5.1-7b451fc-linux-64bit bin

--- a/ci/openstack/validate.sh
+++ b/ci/openstack/validate.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 source ci/openstack/vars.sh
 if [ "${RUN_OPENSTACK_CI:-}" != "true" ]; then
     echo RUN_OPENSTACK_CI is set to false, skipping the openstack end to end test.
     exit
 fi
+
+mkdir -p bin
+scp -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" openshift@master-0.$ENV_ID.example.com:/usr/bin/oc bin/
+ls -alh bin
 
 export PATH="$PWD/bin:$PATH"
 ENV_ID="openshift-$TRAVIS_BUILD_NUMBER"


### PR DESCRIPTION
#### What does this PR do?
The end to end scripts just started failing because the contents of the
tarball shipping the oc tool changed.

Since the binary is always available on the master node after a
successful deployment, let us just copy it from there.


#### How should this be manually tested?
No manual testing necessary. Just make sure the end to end openstack CI succeeds.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @Tlacenka @tzumainn  @bogdando PTAL
