### PR TITLE
Remove `set -x` from the e2e ci pod validation

### DIFF
--- a/ci/openstack/validate.sh
+++ b/ci/openstack/validate.sh
@@ -19,6 +19,8 @@ oc login --insecure-skip-tls-verify=true https://master-0.$ENV_ID.example.com:84
 oc new-project test
 oc new-app --template=cakephp-mysql-example
 
+set +x
+
 echo Waiting for the pods to come up
 
 STATUS=timeout


### PR DESCRIPTION
#### What does this PR do?

We've set the verbose logging too eagerly and it ends up spewing a lot
of useless input in the "waiting for the pods to come up" phase.


#### How should this be manually tested?
No manual testing necessary, just take a look at the final stage of the openstack end to end CI output and verify that it just prints out dots instead of:

```
Waiting for the pods to come up
+STATUS=timeout
++seq 600
+for i in '$(seq 600)'
++oc status -v
++wc -l
++grep 'deployment.*deployed'
+'[' 0 -eq 2 ']'
++oc status -v
++wc -l
++grep -i 'error\|fail'
+'[' 0 -gt 0 ']'
+printf .
```

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @Tlacenka @tzumainn  @bogdando PTAL
