### PR TITLE
Use overlay2 in GCP ref. arch.

### DIFF
--- a/reference-architecture/gcp/ansible/playbooks/roles/dns-records/tasks/main.yaml
+++ b/reference-architecture/gcp/ansible/playbooks/roles/dns-records/tasks/main.yaml
@@ -21,6 +21,7 @@
     type: '{{ item.type }}'
     record_data: '{{ item.record_data }}'
     ttl: 3600
+    overwrite: true
     state: present
   with_items:
   - record: '{{ openshift_master_cluster_public_hostname }}'

--- a/reference-architecture/gcp/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
+++ b/reference-architecture/gcp/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
@@ -52,12 +52,8 @@
     - google-config
     - google-compute-engine
     - google-compute-engine-init
-    when: openshift_deployment_type == 'openshift-enterprise'
-
-  - name: install cloud-init
-    package:
-      name: cloud-init
-      state: present
+    - cloud-init
+    - docker
 
   - name: add disk_setup to cloud_config_modules
     lineinfile:

--- a/reference-architecture/gcp/deployment-manager/core.jinja
+++ b/reference-architecture/gcp/deployment-manager/core.jinja
@@ -72,12 +72,21 @@ resources:
             #cloud-config
             write_files:
             - content: |
-                DEVS='/dev/disk/by-id/google-docker'
-                VG='docker-vol'
-                DATA_SIZE='95%VG'
-                EXTRA_DOCKER_STORAGE_OPTIONS='--storage-opt dm.basesize=3G'
-              path: /etc/sysconfig/docker-storage-setup
+                DOCKER_STORAGE_OPTIONS='--storage-driver overlay2'
+              path: /etc/sysconfig/docker-storage
               permissions: '0644'
+
+            fs_setup:
+            - label: docker
+              filesystem: xfs
+              device: /dev/disk/by-id/google-docker
+              partition: none
+
+            mounts:
+            - [ '/dev/disk/by-id/google-docker', '/var/lib/docker', 'xfs', 'defaults', '0', '0'
+
+            runcmd:
+            - [ /usr/sbin/restorecon, -R, /var/lib/docker ]
       {% else %}
       metadata: {}
       {% endif %}
@@ -144,21 +153,26 @@ resources:
             #cloud-config
             write_files:
             - content: |
-                DEVS='/dev/disk/by-id/google-docker'
-                VG='docker-vol'
-                DATA_SIZE='95%VG'
-                EXTRA_DOCKER_STORAGE_OPTIONS='--storage-opt dm.basesize=3G'
-              path: /etc/sysconfig/docker-storage-setup
+                DOCKER_STORAGE_OPTIONS='--storage-driver overlay2'
+              path: /etc/sysconfig/docker-storage
               permissions: '0644'
 
             fs_setup:
+            - label: docker
+              filesystem: xfs
+              device: /dev/disk/by-id/google-docker
+              partition: none
             - label: osl
               filesystem: xfs
               device: /dev/disk/by-id/google-openshift
               partition: none
 
             mounts:
+            - [ '/dev/disk/by-id/google-docker', '/var/lib/docker', 'xfs', 'defaults', '0', '0' ]
             - [ '/dev/disk/by-id/google-openshift', '/var/lib/origin/openshift.local.volumes', 'xfs', 'defaults,gquota', '0', '0' ]
+
+            runcmd:
+            - [ /usr/sbin/restorecon, -R, /var/lib/docker ]
       networkInterfaces:
       - accessConfigs:
         - name: external-nat
@@ -222,21 +236,26 @@ resources:
             #cloud-config
             write_files:
             - content: |
-                DEVS='/dev/disk/by-id/google-docker'
-                VG='docker-vol'
-                DATA_SIZE='95%VG'
-                EXTRA_DOCKER_STORAGE_OPTIONS='--storage-opt dm.basesize=3G'
-              path: /etc/sysconfig/docker-storage-setup
+                DOCKER_STORAGE_OPTIONS='--storage-driver overlay2'
+              path: /etc/sysconfig/docker-storage
               permissions: '0644'
 
             fs_setup:
+            - label: docker
+              filesystem: xfs
+              device: /dev/disk/by-id/google-docker
+              partition: none
             - label: osl
               filesystem: xfs
               device: /dev/disk/by-id/google-openshift
               partition: none
 
             mounts:
+            - [ '/dev/disk/by-id/google-docker', '/var/lib/docker', 'xfs', 'defaults', '0', '0' ]
             - [ '/dev/disk/by-id/google-openshift', '/var/lib/origin/openshift.local.volumes', 'xfs', 'defaults,gquota', '0', '0' ]
+
+            runcmd:
+            - [ /usr/sbin/restorecon, -R, /var/lib/docker ]
       networkInterfaces:
       - accessConfigs:
         - name: external-nat


### PR DESCRIPTION
#### What does this PR do?
Use overlay2 in GCP ref. arch. Pre-install docker in gold image. Enable overwriting of DNS records, so some redeploy use-cases are faster.

#### How should this be manually tested?
Verify that OCP deploys on GCP correctly, and docker uses overlay storage on separate disk.

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
cc: @cooktheryan  PTAL