### PR TITLE
Pin openshift ansible in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
 env:
   global:
     - CI_CONCURRENT_JOBS=1
-    - OPENSHIFT_ANSIBLE_COMMIT=master
+    - OPENSHIFT_ANSIBLE_COMMIT=1febf0b20de622d358dc890417dc4cda7c3f71a9
   matrix:
     - RUN_OPENSTACK_CI=false
     - RUN_OPENSTACK_CI=true

--- a/ci/openstack/install.sh
+++ b/ci/openstack/install.sh
@@ -16,6 +16,7 @@ fi
 git clone https://github.com/openshift/openshift-ansible ../openshift-ansible
 cd ../openshift-ansible
 git checkout "${OPENSHIFT_ANSIBLE_COMMIT:-master}"
+git status
 cd ../openshift-ansible-contrib
 
 pip install ansible shade dnspython python-openstackclient python-heatclient


### PR DESCRIPTION
#### What does this PR do?
This pins a specific openshift-ansible version in the openstack end to end CI that sholudn't be broken for us.

#### How should this be manually tested?
The end to end ci should pass. No manual testing necessary.

#### Is there a relevant Issue open for this?
Issue #686 

#### Who would you like to review this?
cc: @Tlacenka @tzumainn  @bogdando PTAL
