### PR TITLE
Support external/pre-provisioned authoritative cluster DNS

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -53,8 +53,9 @@ Otherwise, even if there are differences between the two versions, installation 
 * Assigns Cinder volumes to the servers
 * Set up an `openshift` user with sudo privileges
 * Optionally attach Red Hat subscriptions
-* Set up a bind-based DNS server
-* When deploying more than one master, set up a HAproxy server
+* Sets up a bind-based DNS server or configures the cluster servers to use an external DNS server.
+* Supports mixed in-stack/external DNS servers for dynamic updates.
+* When deploying more than one master, sets up a HAproxy server
 
 
 ## Set up
@@ -69,8 +70,16 @@ Otherwise, even if there are differences between the two versions, installation 
 
 ### Update `inventory/group_vars/all.yml`
 
+#### DNS configuration variables
+
 Pay special attention to the values in the first paragraph -- these
 will depend on your OpenStack environment.
+
+Note that the provsisioning playbooks update the original Neutron subnet
+created with the Heat stack to point to the configured DNS servers.
+So the provisioned cluster nodes will start using those natively as
+default nameservers. Technically, this allows to deploy OpenShift clusters
+without dnsmasq proxies.
 
 The `env_id` and `public_dns_domain` will form the cluster's DNS domain all
 your servers will be under. With the default values, this will be
@@ -93,10 +102,45 @@ daemon that in turn proxies DNS requests to the authoritative DNS server.
 When Network Manager is enabled for provisioned cluster nodes, which is
 normally the case, you should not change the defaults and always deploy dnsmasq.
 
-Note that the authoritative DNS server is configured on post provsision
-steps, and the Neutron subnet for the Heat stack is updated to point to that
-server in the end. So the provisioned servers will start using it natively
-as a default nameserver that comes from the NetworkManager and cloud-init.
+`external_nsupdate_keys` describes an external authoritative DNS server(s)
+processing dynamic records updates in the public and private cluster views:
+
+    external_nsupdate_keys:
+      public:
+        key_secret: <some nsupdate key>
+        key_algorithm: 'hmac-md5'
+        key_name: 'update-key'
+        server: <public DNS server IP>
+      private:
+        key_secret: <some nsupdate key 2>
+        key_algorithm: 'hmac-sha256'
+        server: <public or private DNS server IP>
+
+Here, for the public view section, we specified another key algorithm and
+optional `key_name`, which normally defaults to the cluster's DNS domain.
+This just illustrates a compatibility mode with a DNS service deployed
+by OpenShift on OSP10 reference architecture, and used in a mixed mode with
+another external DNS server.
+
+Another example defines an external DNS server for the public view
+additionally to the in-stack DNS server used for the private view only:
+
+    external_nsupdate_keys:
+      public:
+        key_secret: <some nsupdate key>
+        key_algorithm: 'hmac-sha256'
+        server: <public DNS server IP>
+
+Here, updates matching the public view will be hitting the given public
+server IP. While updates matching the private view will be sent to the
+auto evaluated in-stack DNS server's **public** IP.
+
+Note, for the in-stack DNS server, private view updates may be sent only
+via the public IP of the server. You can not send updates via the private
+IP yet. This forces the in-stack private server to have a floating IP.
+See also the [security notes](#security-notes)
+
+#### Other configuration variables
 
 `openstack_ssh_key` is a Nova keypair - you can see your keypairs with
 `openstack keypair list`. This guide assumes that its corresponding private

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -14,6 +14,7 @@
     nsupdate_server_private: "{{ external_nsupdate_keys['private']['server'] }}"
     nsupdate_key_secret_private: "{{ external_nsupdate_keys['private']['key_secret'] }}"
     nsupdate_key_algorithm_private: "{{ external_nsupdate_keys['private']['key_algorithm'] }}"
+    nsupdate_private_key_name: "{{ external_nsupdate_keys['private']['key_name']|default('private-' + full_dns_domain) }}"
   when:
     - external_nsupdate_keys is defined
     - external_nsupdate_keys['private'] is defined
@@ -32,7 +33,7 @@
       - view: "private"
         zone: "{{ full_dns_domain }}"
         server: "{{ nsupdate_server_private }}"
-        key_name: "{{ ( 'private-' + full_dns_domain ) }}"
+        key_name: "{{ nsupdate_private_key_name|default('private-' + full_dns_domain) }}"
         key_secret: "{{ nsupdate_key_secret_private }}"
         key_algorithm: "{{ nsupdate_key_algorithm_private | lower }}"
         entries: "{{ private_records }}"
@@ -54,6 +55,7 @@
     nsupdate_server_public: "{{ external_nsupdate_keys['public']['server'] }}"
     nsupdate_key_secret_public: "{{ external_nsupdate_keys['public']['key_secret'] }}"
     nsupdate_key_algorithm_public: "{{ external_nsupdate_keys['public']['key_algorithm'] }}"
+    nsupdate_public_key_name: "{{ external_nsupdate_keys['public']['key_name']|default('public-' + full_dns_domain) }}"
   when:
     - external_nsupdate_keys is defined
     - external_nsupdate_keys['public'] is defined
@@ -72,7 +74,7 @@
       - view: "public"
         zone: "{{ full_dns_domain }}"
         server: "{{ nsupdate_server_public }}"
-        key_name: "{{ ( 'public-' + full_dns_domain ) }}"
+        key_name: "{{ nsupdate_public_key_name|default('public-' + full_dns_domain) }}"
         key_secret: "{{ nsupdate_key_secret_public }}"
         key_algorithm: "{{ nsupdate_key_algorithm_public | lower }}"
         entries: "{{ public_records }}"

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -54,6 +54,7 @@ outputs:
     description: Floating IPs of the nodes
     value: { get_attr: [ infra_nodes, floating_ip ] }
 
+{% if num_dns|int > 0 %}
   dns_name:
     description: Name of the DNS
     value:
@@ -68,6 +69,7 @@ outputs:
   dns_private_ips:
     description: Private IPs of the DNS
     value: { get_attr: [ dns, private_ip ] }
+{% endif %}
 
 resources:
 
@@ -405,6 +407,7 @@ resources:
           port_range_min: 443
           port_range_max: 443
 
+{% if num_dns|int > 0 %}
   dns-secgrp:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -439,6 +442,8 @@ resources:
           port_range_min: 53
           port_range_max: 53
           remote_ip_prefix: "{{ openstack_subnet_prefix }}.0/24"
+{% endif %}
+
 {% if num_masters|int > 1 or ui_ssh_tunnel|bool %}
   lb-secgrp:
     type: OS::Neutron::SecurityGroup
@@ -716,6 +721,7 @@ resources:
     depends_on:
       - interface
 
+{% if num_dns|int > 0 %}
   dns:
     type: OS::Heat::ResourceGroup
     properties:
@@ -755,3 +761,4 @@ resources:
           volume_size: {{ dns_volume_size }}
     depends_on:
       - interface
+{% endif %}


### PR DESCRIPTION
#### What does this PR do?
* Document how to use fully external DNS servers w/o provisioning
  dns servers group with Heat.

* Document how to use a mixed servers setup for dynamic records
  updates mathing public or private views.

* Allow custom public key names for OSP10 dns service compatibility.
  The osp-dns configures the named service with the fixed key_name
  'update-key'. Add optional key_name for the external_nsupdate_keys
  public section to allow custom key names.

#### How should this be manually tested?
Fully external DNS server:

* Deploy s DNS server (f.e. by [this guide](https://github.com/openshift/openshift-ansible-contrib/tree/master/reference-architecture/osp-dns)) and populate an inventory file (e.g. `inventory/external_dns.yaml`) with its nsupdate data
* Run provision openstack with app nodes count of 1 and dns nodes count of 0, and add 
  `-e@inventory/external_dns.yaml` for the ansible-playbook commands used
* Finish e2e (it shall pass)
* Run provision openstack with app nodes count of 2 and dns nodes count of 0 and add 
  `-e@inventory/external_dns.yaml` for the ansible-playbook commands used
* Finish e2e (it shall pass)
* Check if all app nodes' FQDNs are resolvable via your external DNS

Mixed instack/external DNS:

* Deploy s DNS server (f.e. by [this guide](https://github.com/openshift/openshift-ansible-contrib/tree/master/reference-architecture/osp-dns)) and populate an inventory file (e.g. 
  `inventory/external_dns.yaml`) `external_nsupdate_keys.public` with the required server, key,
  algorithm data.
* Run provision openstack with app nodes count of 1 and dns nodes count of 1, and add
  `-e@inventory/external_dns.yaml` for the ansible-playbook commands used
* Finish e2e (it shall pass)
* Run provision openstack with app nodes count of 2 and dns nodes count of 1 and add
  `-e@inventory/external_dns.yaml` for the ansible-playbook commands used
* Finish e2e (it shall pass)
* Check if:
  * app nodes' public FQDNs are resolvable via your external DNS (run nslookup or dig against the public 
     DNS server public IP)
  * the private DNS server is used for a private view (run nslookup or dig from a cluster node to verify 
     this).

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic @oybed PTAL
