### PR TITLE
Brownfield BYO Bastion Template

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/main.yaml
@@ -8,7 +8,7 @@
   when: create_vpc == "no" and byo_bastion == "no"
 
 - name: Render Brownfield BYO Bastion Template
-  template: src=roles/cloudformation-infra/files/brownfield-byo-bastion.json.j2 dest=roles/cloudformation-infra/files/{{ stack_name }}brownfield-byo-bastion.json
+  template: src=roles/cloudformation-infra/files/brownfield-byo-bastion.json.j2 dest=roles/cloudformation-infra/files/{{ stack_name }}-brownfield-byo-bastion.json
   when: create_vpc == "no" and byo_bastion == "yes"
 
 - name: Create Greenfield Infrastructure


### PR DESCRIPTION


#### What does this PR do?
Fix task "Render Brownfield BYO Bastion Template".
The dest file name does not have dash

BEFORE:
`
{{ stack_name }}brownfield-byo-bastion.json
`
AFTER:
`
{{ stack_name }}-brownfield-byo-bastion.json
`



#### How should this be manually tested?
Launch in Brownfield deployment mode.

`
./ose-on-aws.py -create-vpc=no --byo-bastion=yes --bastion-sg=sg-123456a 
`

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
