### PR TITLE
Invalid JSON Format

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/brownfield-byo-bastion.json.j2
@@ -775,7 +775,7 @@
             "Type": "A",
                         "TTL": "300",
                     "ResourceRecords": [{ "Fn::GetAtt" : ["InfraNode03", "PrivateIp"] }]
-          },
+          }
         ]
       }
     },


### PR DESCRIPTION


#### What does this PR do?
Removed a comma which causes Invalid JSON Format during Create Brownfield Infrastructure with existing bastion task


#### How should this be manually tested?
Launch in Brownfield deployment mode.
`
./ose-on-aws.py -create-vpc=no --byo-bastion=yes --bastion-sg=sg-123456a
`
#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
