### PR TITLE
Document global DNS security options

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -85,6 +85,8 @@ default hostname (usually the role name) is used.
 The `public_dns_nameservers` is a list of DNS servers accessible from all
 the created Nova servers. These will be serving as your DNS forwarders for
 external FQDNs that do not belong to the cluster's DNS domain and its subdomains.
+If you're unsure what to put in here, you can try the google or opendns servers,
+but note that some organizations may be blocking them.
 
 The `openshift_use_dnsmasq` controls either dnsmasq is deployed or not.
 By default, dnsmasq is deployed and comes as the hosts' /etc/resolv.conf file

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -200,6 +200,18 @@ be the case for development environments. When turned off, the servers will
 be provisioned omitting the ``yum update`` command. This brings security
 implications though, and is not recommended for production deployments.
 
+##### DNS servers security options
+
+Aside from `node_ingress_cidr` restricting public access to in-stack DNS
+servers, there are following (bind/named specific) DNS security
+options available:
+
+    named_public_recursion: 'no'
+    named_private_recursion: 'yes'
+
+External DNS servers, which is not included in the 'dns' hosts group,
+are not managed. It is up to you to configure such ones.
+
 ### Configure the OpenShift parameters
 
 Finally, you need to update the DNS entry in

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -92,6 +92,10 @@ rhsm_register: False
 #    key_algorithm: 'hmac-md5'
 #    server: '192.168.1.2'
 
+# # Customize DNS server security options
+#named_public_recursion: 'no'
+#named_private_recursion: 'yes'
+
 
 # NOTE(shadower): Do not change this value. The Ansible user is currently
 # hardcoded to `openshift`.

--- a/roles/dns-views/defaults/main.yml
+++ b/roles/dns-views/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+external_nsupdate_keys: {}
+named_private_recursion: 'yes'
+named_public_recursion: 'no'

--- a/roles/dns-views/tasks/main.yml
+++ b/roles/dns-views/tasks/main.yml
@@ -8,18 +8,22 @@
   set_fact:
     private_named_view:
       - name: "private"
+        recursion: "{{ named_private_recursion }}"
         acl_entry: "{{ acl_list }}"
         zone:
           - dns_domain: "{{ full_dns_domain }}"
+  when: external_nsupdate_keys['private'] is undefined
 
 - name: "Generate the public view"
   set_fact:
     public_named_view:
       - name: "public"
+        recursion: "{{ named_public_recursion }}"
         zone:
           - dns_domain: "{{ full_dns_domain }}"
         forwarder: "{{ public_dns_nameservers }}"
+  when: external_nsupdate_keys['public'] is undefined
 
 - name: "Generate the final named_config_views"
   set_fact:
-    named_config_views: "{{ private_named_view + public_named_view }}"
+    named_config_views: "{{ private_named_view|default([]) + public_named_view|default([]) }}"

--- a/roles/dns-views/tasks/main.yml
+++ b/roles/dns-views/tasks/main.yml
@@ -12,6 +12,7 @@
         acl_entry: "{{ acl_list }}"
         zone:
           - dns_domain: "{{ full_dns_domain }}"
+        forwarder: "{{ public_dns_nameservers }}"
   when: external_nsupdate_keys['private'] is undefined
 
 - name: "Generate the public view"


### PR DESCRIPTION
#### What does this PR do?
Depends on https://github.com/redhat-cop/infra-ansible/pull/69

* Document global DNS security options, specifically a recursion switches.
* Do not create a view if externally managed.
* Allow to specify the recursion settings for public/private views defined by the dns-view role.

note: dnsses is yet to be supported

#### How should this be manually tested?
Defaults are left as is and need no to be tested.
A secure setup recommended in the guide, should be tested:

* Define inventory vars:
  ```
  named_config_recursion: 'no'
  named_config_views:
    public:
      - recursion: 'no'
      ... (remaining data for the infra-ansible casl dns role) ...
  ```
* Provision a non-recursive public DNS, by [casl dns* roles](https://github.com/redhat-cop/infra-ansible/tree/master/roles/dns-server), using the inventory vars defined above. See this [example playbook](https://github.com/bogdando/ocp-inventory/blob/master/playbooks/deploy-dns-casl.yaml) based on the [osp 10 ref arch DNS service](https://github.com/openshift/openshift-ansible-contrib/tree/master/reference-architecture/osp-dns) 'hacked' to use the infra-ansible casl dns role.
* Provision and deploy a mixed DNS servers setup, having an in-stack private DNS allowing recursion.
* e2e shall pass
* Verify there is no recursion available for the external DNS:
```
dig foo.com @<IP>
WARNING: recursion requested but not available
```
* Repeat the steps with an in-stack DNS server used for priv/pub views, and define `named_public_recursion: 'no'`.

#### Is there a relevant Issue open for this?
Related https://github.com/openshift/openshift-ansible-contrib/issues/621

#### Who would you like to review this?
cc: @tomassedovic @oybed PTAL
