### PR TITLE
Add custom post-provision playbook for adding yum repos

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -325,7 +325,23 @@ if requested, and DNS server, and ensures other OpenShift requirements to be met
 
 ### Running Custom Post-Provision Actions
 
-If you'd like to run post-provision actions, you can do so by creating a custom playbook. Here's one example that adds additional YUM repositories:
+A library of custom post-provision actions exists in `openshift-ansible-contrib/playbooks/provision/openstack/custom-actions`. Playbooks include:
+
+  - add-yum-repos.yml
+
+A custom playbook can be run like this:
+
+```
+ansible-playbook --private-key ~/.ssh/openshift -i myinventory/ openshift-ansible-contrib/playbooks/provision/openstack/custom-actions/custom-playbook.yml
+```
+
+If you'd like to limit the run to one particular host, you can do so as follows:
+
+```
+ansible-playbook --private-key ~/.ssh/openshift -i myinventory/ openshift-ansible-contrib/playbooks/provision/openstack/custom-actions/custom-playbook.yml -l app-node-0.openshift.example.com
+```
+
+You can also create your own custom playbook. Here's one example that adds additional YUM repositories:
 
 ```
 ---
@@ -349,17 +365,7 @@ This example runs against app nodes. The list of options include:
   - masters
   - infra_hosts
 
-After writing your custom playbook, run it like this:
-
-```
-ansible-playbook --private-key ~/.ssh/openshift -i myinventory/ custom-playbook.yaml
-```
-
-If you'd like to limit the run to one particular host, you can do so as follows:
-
-```
-ansible-playbook --private-key ~/.ssh/openshift -i myinventory/ custom-playbook.yaml -l app-node-0.openshift.example.com
-```
+Please consider contributing your custom playbook back to openshift-ansible-contrib!
 
 ### Install OpenShift
 

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -325,20 +325,16 @@ if requested, and DNS server, and ensures other OpenShift requirements to be met
 
 ### Running Custom Post-Provision Actions
 
-A library of custom post-provision actions exists in `openshift-ansible-contrib/playbooks/provision/openstack/custom-actions`. Playbooks include:
-
-  - add-yum-repos.yml
-
 A custom playbook can be run like this:
 
 ```
-ansible-playbook --private-key ~/.ssh/openshift -i myinventory/ openshift-ansible-contrib/playbooks/provision/openstack/custom-actions/custom-playbook.yml
+ansible-playbook --private-key ~/.ssh/openshift -i inventory/ openshift-ansible-contrib/playbooks/provisioning/openstack/custom-actions/custom-playbook.yml
 ```
 
 If you'd like to limit the run to one particular host, you can do so as follows:
 
 ```
-ansible-playbook --private-key ~/.ssh/openshift -i myinventory/ openshift-ansible-contrib/playbooks/provision/openstack/custom-actions/custom-playbook.yml -l app-node-0.openshift.example.com
+ansible-playbook --private-key ~/.ssh/openshift -i inventory/ openshift-ansible-contrib/playbooks/provisioning/openstack/custom-actions/custom-playbook.yml -l app-node-0.openshift.example.com
 ```
 
 You can also create your own custom playbook. Here's one example that adds additional YUM repositories:
@@ -366,6 +362,12 @@ This example runs against app nodes. The list of options include:
   - infra_hosts
 
 Please consider contributing your custom playbook back to openshift-ansible-contrib!
+
+A library of custom post-provision actions exists in `openshift-ansible-contrib/playbooks/provisioning/openstack/custom-actions`. Playbooks include:
+
+##### add-yum-repos.yml
+
+[add-yum-repos.yml](https://github.com/openshift/openshift-ansible-contrib/blob/master/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml) adds a list of custom yum repositories to every node in the cluster.
 
 ### Install OpenShift
 

--- a/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml
+++ b/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml
@@ -1,0 +1,11 @@
+- hosts: cluster_hosts
+  vars:
+    yum_repos: []
+  tasks:
+  # enable additional yum repos
+  - name: Add repository
+    yum_repository:
+      name: "{{ item.name }}"
+      description: "{{ item.description }}"
+      baseurl: "{{ item.baseurl }}"
+    with_items: "{{ yum_repos }}"

--- a/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml
+++ b/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml
@@ -1,3 +1,4 @@
+---
 - hosts: cluster_hosts
   vars:
     yum_repos: []


### PR DESCRIPTION
#### What does this PR do?
Adds a custom post-provision playbook for adding yum repos; updates documentation to reference the custom-actions directory

#### How should this be manually tested?

ansible-playbook --private-key ~/.ssh/openshift -i myinventory/ openshift-ansible-contrib/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml -l app-node-0.openshift.example.com --extra-vars "yum_repos=[{'name':'test','description':'This is a test','baseurl':'https://test.url/'}]"

Verify that repo is added on app-node-0 in /etc/yum.repos.d; remove it afterwards

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic @bogdando @Tlacenka  PTAL
