### PR TITLE
Switch openshift-ansible back to master in the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
 env:
   global:
     - CI_CONCURRENT_JOBS=1
-    - OPENSHIFT_ANSIBLE_COMMIT=1febf0b20de622d358dc890417dc4cda7c3f71a9
+    - OPENSHIFT_ANSIBLE_COMMIT=master
   matrix:
     - RUN_OPENSTACK_CI=false
     - RUN_OPENSTACK_CI=true


### PR DESCRIPTION
#### What does this PR do?

Uses the `master` branch of openshift-ansible in the Openstack end to end CI.

#### How should this be manually tested?
No manual testing. Just verify that the end to end openstack ci passes.


#### Is there a relevant Issue open for this?
#686


#### Who would you like to review this?
cc: @Tlacenka @tzumainn  @bogdando PTAL
