### PR TITLE
Allow using a provider network

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -244,6 +244,26 @@ be the case for development environments. When turned off, the servers will
 be provisioned omitting the ``yum update`` command. This brings security
 implications though, and is not recommended for production deployments.
 
+#### Provider Network
+
+Normally, the playbooks create a new Neutron network and subnet and attach
+floating IP addresses to each node. If you have a provider network set up, this
+is all unnecessary as you can just access servers that are placed in the
+provider network directly.
+
+To use a provider network, set its name in `openstack_provider_network_name` in
+`inventory/group_vars/all.yml`.
+
+You must also unset the `openstack_external_network_name` and
+`openstack_private_network_name` fields.
+
+**NOTE**: this will not update the nodes' DNS, so running openshift-ansible
+right after provisioning will fail (unless you're using an external DNS server
+your provider network knows about). You must make sure your nodes are able to
+resolve each other by name, e.g. by setting `dns_nameservers` on your subnet or
+editing each node's `/etc/resolv.conf`.
+
+
 ### Configure the OpenShift parameters
 
 Finally, you need to update the DNS entry in

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -254,15 +254,13 @@ provider network directly.
 To use a provider network, set its name in `openstack_provider_network_name` in
 `inventory/group_vars/all.yml`.
 
-You must also unset the `openstack_external_network_name` and
-`openstack_private_network_name` fields.
+If you set the provider network name, the `openstack_external_network_name` and
+`openstack_private_network_name` fields will be ignored.
 
 **NOTE**: this will not update the nodes' DNS, so running openshift-ansible
 right after provisioning will fail (unless you're using an external DNS server
 your provider network knows about). You must make sure your nodes are able to
-resolve each other by name, e.g. by setting `dns_nameservers` on your subnet or
-editing each node's `/etc/resolv.conf`.
-
+resolve each other by name.
 
 ### Configure the OpenShift parameters
 

--- a/playbooks/provisioning/openstack/prerequisites.yml
+++ b/playbooks/provisioning/openstack/prerequisites.yml
@@ -87,20 +87,6 @@
       that: 'key_result.rc == 0'
       msg: "Keypair {{ openstack_ssh_public_key }} is not available"
 
-  - name: The provider and private networks can't be set at the same time
-    fail:
-      msg: You cannot set both `openstack_provider_network_name` and `openstack_private_network_name` at the same time
-    when:
-    - openstack_provider_network_name|default(None)
-    - openstack_private_network_name|default(None)
-
-  - name: The provider and external networks can't be set at the same time
-    fail:
-      msg: You cannot set both `openstack_provider_network_name` and `openstack_external_network_name` at the same time
-    when:
-    - openstack_provider_network_name|default(None)
-    - openstack_external_network_name|default(None)
-
 # Check that custom images and flavors exist
 - hosts: localhost
 

--- a/playbooks/provisioning/openstack/prerequisites.yml
+++ b/playbooks/provisioning/openstack/prerequisites.yml
@@ -65,10 +65,12 @@
     os_networks_facts:
       name: "{{ openstack_external_network_name }}"
     register: network_result
+    when: not openstack_provider_network_name|default(None)
   - name: Check that network is available
     assert:
       that: "network_result.ansible_facts.openstack_networks"
       msg: "Network {{ openstack_external_network_name }} is not available"
+    when: not openstack_provider_network_name|default(None)
 
   # Check keypair
   # TODO kpilatov: there is no Ansible module for getting OS keypairs
@@ -84,6 +86,20 @@
     assert:
       that: 'key_result.rc == 0'
       msg: "Keypair {{ openstack_ssh_public_key }} is not available"
+
+  - name: The provider and private networks can't be set at the same time
+    fail:
+      msg: You cannot set both `openstack_provider_network_name` and `openstack_private_network_name` at the same time
+    when:
+    - openstack_provider_network_name|default(None)
+    - openstack_private_network_name|default(None)
+
+  - name: The provider and external networks can't be set at the same time
+    fail:
+      msg: You cannot set both `openstack_provider_network_name` and `openstack_external_network_name` at the same time
+    when:
+    - openstack_provider_network_name|default(None)
+    - openstack_external_network_name|default(None)
 
 # Check that custom images and flavors exist
 - hosts: localhost

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -17,8 +17,9 @@ openstack_external_network_name: "public"
 #openstack_private_network_name:  "openshift-ansible-{{ stack_name }}-net"
 
 ## If you want to use a provider network, set its name here.
-## NOTE: you must remove the `openstack_external_network_name` and
-## `openstack_private_network_name` options above.
+## NOTE: the `openstack_external_network_name` and
+## `openstack_private_network_name` options will be ignored when using a
+## provider network.
 #openstack_provider_network_name: "provider"
 
 # # Used Images

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -16,6 +16,11 @@ openstack_ssh_public_key: "openshift"
 openstack_external_network_name: "public"
 #openstack_private_network_name:  "openshift-ansible-{{ stack_name }}-net"
 
+## If you want to use a provider network, set its name here.
+## NOTE: you must remove the `openstack_external_network_name` and
+## `openstack_private_network_name` options above.
+#openstack_provider_network_name: "provider"
+
 # # Used Images
 # # - set specific images for roles by uncommenting corresponding lines
 # # - note: do not remove openstack_default_image_name definition

--- a/playbooks/provisioning/openstack/stack_params.yaml
+++ b/playbooks/provisioning/openstack/stack_params.yaml
@@ -23,8 +23,14 @@ openstack_node_image: "{{ openstack_node_image_name | default(openstack_default_
 openstack_lb_image: "{{ openstack_lb_image_name | default(openstack_default_image_name) }}"
 openstack_etcd_image: "{{ openstack_etcd_image_name | default(openstack_default_image_name) }}"
 openstack_dns_image: "{{ openstack_dns_image_name | default(openstack_default_image_name) }}"
-openstack_private_network: "{{ openstack_private_network_name | default ('openshift-ansible-' + stack_name + '-net') }}"
-external_network: "{{ openstack_external_network_name }}"
+openstack_private_network: >-
+  {% if openstack_provider_network_name | default(None) -%}
+  {{ openstack_provider_network_name }}
+  {%- else -%}
+  {{ openstack_private_network_name | default ('openshift-ansible-' + stack_name + '-net') }}
+  {%- endif -%}
+provider_network: "{{ openstack_provider_network_name | default(None) }}"
+external_network: "{{ openstack_external_network_name | default(None) }}"
 num_etcd: "{{ openstack_num_etcd | default(0) }}"
 num_masters: "{{ openstack_num_masters }}"
 num_nodes: "{{ openstack_num_nodes }}"

--- a/roles/openstack-stack/defaults/main.yml
+++ b/roles/openstack-stack/defaults/main.yml
@@ -15,3 +15,4 @@ dns_volume_size: 1
 lb_volume_size: 5
 use_bastion: False
 ui_ssh_tunnel: False
+provider_network: None

--- a/roles/openstack-stack/tasks/subnet_update_dns_servers.yaml
+++ b/roles/openstack-stack/tasks/subnet_update_dns_servers.yaml
@@ -6,3 +6,4 @@
     state: present
     use_default_subnetpool: yes
     dns_nameservers: "{{ [private_dns_server|default(public_dns_nameservers[0])]|union(public_dns_nameservers)|unique }}"
+  when: not openstack_provider_network_name|default(None)

--- a/roles/openstack-stack/tasks/subnet_update_dns_servers.yaml
+++ b/roles/openstack-stack/tasks/subnet_update_dns_servers.yaml
@@ -6,4 +6,4 @@
     state: present
     use_default_subnetpool: yes
     dns_nameservers: "{{ [private_dns_server|default(public_dns_nameservers[0])]|union(public_dns_nameservers)|unique }}"
-  when: not openstack_provider_network_name|default(None)
+  when: not provider_network

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -73,6 +73,7 @@ outputs:
 
 resources:
 
+{% if not provider_network %}
   net:
     type: OS::Neutron::Net
     properties:
@@ -128,6 +129,8 @@ resources:
     properties:
       router_id: { get_resource: router }
       subnet_id: { get_resource: subnet }
+
+{% endif %}
 
 #  keypair:
 #    type: OS::Nova::KeyPair
@@ -501,22 +504,29 @@ resources:
           image:       {{ openstack_etcd_image }}
           flavor:      {{ etcd_flavor }}
           key_name:    {{ ssh_public_key }}
+{% if provider_network %}
+          net:         {{ provider_network }}
+          net_name:         {{ provider_network }}
+{% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
-          secgrp:
-            - { get_resource: {% if openstack_flat_secgrp|default(False)|bool %}flat-secgrp{% else %}etcd-secgrp{% endif %} }
-            - { get_resource: common-secgrp }
-{% if not use_bastion|bool %}
-          floating_network: {{ external_network }}
-{% endif %}
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ stack_name }}
+{% endif %}
+          secgrp:
+            - { get_resource: {% if openstack_flat_secgrp|default(False)|bool %}flat-secgrp{% else %}etcd-secgrp{% endif %} }
+            - { get_resource: common-secgrp }
+{% if not use_bastion|bool and not provider_network %}
+          floating_network: {{ external_network }}
+{% endif %}
           volume_size: {{ etcd_volume_size }}
+{% if not provider_network %}
     depends_on:
       - interface
+{% endif %}
 
 {% if num_masters|int > 1 %}
   loadbalancer:
@@ -544,20 +554,29 @@ resources:
           image:       {{ openstack_lb_image }}
           flavor:      {{ lb_flavor }}
           key_name:    {{ ssh_public_key }}
+{% if provider_network %}
+          net:         {{ provider_network }}
+          net_name:         {{ provider_network }}
+{% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
-          secgrp:
-            - { get_resource: lb-secgrp }
-            - { get_resource: common-secgrp }
-          floating_network: {{ external_network }}
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ stack_name }}
+{% endif %}
+          secgrp:
+            - { get_resource: lb-secgrp }
+            - { get_resource: common-secgrp }
+    {% if not provider_network %}
+          floating_network: {{ external_network }}
+    {% endif %}
           volume_size: {{ lb_volume_size }}
+    {% if not provider_network %}
     depends_on:
       - interface
+    {% endif %}
 {% endif %}
 
   masters:
@@ -589,8 +608,18 @@ resources:
           image:       {{ openstack_master_image }}
           flavor:      {{ master_flavor }}
           key_name:    {{ ssh_public_key }}
+{% if provider_network %}
+          net:         {{ provider_network }}
+          net_name:         {{ provider_network }}
+{% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
+          net_name:
+            str_replace:
+              template: openshift-ansible-cluster_id-net
+              params:
+                cluster_id: {{ stack_name }}
+{% endif %}
           secgrp:
 {% if openstack_flat_secgrp|default(False)|bool %}
             - { get_resource: flat-secgrp }
@@ -602,17 +631,14 @@ resources:
 {% endif %}
 {% endif %}
             - { get_resource: common-secgrp }
-{% if not use_bastion|bool %}
+{% if not use_bastion|bool and not provider_network %}
           floating_network: {{ external_network }}
 {% endif %}
-          net_name:
-            str_replace:
-              template: openshift-ansible-cluster_id-net
-              params:
-                cluster_id: {{ stack_name }}
           volume_size: {{ master_volume_size }}
+{% if not provider_network %}
     depends_on:
       - interface
+{% endif %}
 
   compute_nodes:
     type: OS::Heat::ResourceGroup
@@ -650,22 +676,29 @@ resources:
           image:       {{ openstack_node_image }}
           flavor:      {{ node_flavor }}
           key_name:    {{ ssh_public_key }}
+{% if provider_network %}
+          net:         {{ provider_network }}
+          net_name:         {{ provider_network }}
+{% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
-          secgrp:
-            - { get_resource: {% if openstack_flat_secgrp|default(False)|bool %}flat-secgrp{% else %}node-secgrp{% endif %} }
-            - { get_resource: common-secgrp }
-{% if not use_bastion|bool %}
-          floating_network: {{ external_network }}
-{% endif %}
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ stack_name }}
+{% endif %}
+          secgrp:
+            - { get_resource: {% if openstack_flat_secgrp|default(False)|bool %}flat-secgrp{% else %}node-secgrp{% endif %} }
+            - { get_resource: common-secgrp }
+{% if not use_bastion|bool and not provider_network %}
+          floating_network: {{ external_network }}
+{% endif %}
           volume_size: {{ node_volume_size }}
+{% if not provider_network %}
     depends_on:
       - interface
+{% endif %}
 
   infra_nodes:
     type: OS::Heat::ResourceGroup
@@ -697,8 +730,18 @@ resources:
           image:       {{ openstack_infra_image }}
           flavor:      {{ infra_flavor }}
           key_name:    {{ ssh_public_key }}
+{% if provider_network %}
+          net:         {{ provider_network }}
+          net_name:         {{ provider_network }}
+{% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
+          net_name:
+            str_replace:
+              template: openshift-ansible-cluster_id-net
+              params:
+                cluster_id: {{ stack_name }}
+{% endif %}
           secgrp:
 # TODO(bogdando) filter only required node rules into infra-secgrp
 {% if openstack_flat_secgrp|default(False)|bool %}
@@ -711,15 +754,14 @@ resources:
 {% endif %}
             - { get_resource: infra-secgrp }
             - { get_resource: common-secgrp }
+{% if not provider_network %}
           floating_network: {{ external_network }}
-          net_name:
-            str_replace:
-              template: openshift-ansible-cluster_id-net
-              params:
-                cluster_id: {{ stack_name }}
+{% endif %}
           volume_size: {{ infra_volume_size }}
+{% if not provider_network %}
     depends_on:
       - interface
+{% endif %}
 
 {% if num_dns|int > 0 %}
   dns:
@@ -747,18 +789,26 @@ resources:
           image:       {{ openstack_dns_image }}
           flavor:      {{ dns_flavor }}
           key_name:    {{ ssh_public_key }}
+{% if provider_network %}
+          net:         {{ provider_network }}
+          net_name:         {{ provider_network }}
+{% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
-          secgrp:
-            - { get_resource: dns-secgrp }
-            - { get_resource: common-secgrp }
-          floating_network: {{ external_network }}
           net_name:
             str_replace:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ stack_name }}
+{% endif %}
+          secgrp:
+            - { get_resource: dns-secgrp }
+            - { get_resource: common-secgrp }
+{% if not provider_network %}
+          floating_network: {{ external_network }}
+{% endif %}
           volume_size: {{ dns_volume_size }}
+{% if not provider_network %}
     depends_on:
       - interface
 {% endif %}

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -812,3 +812,4 @@ resources:
     depends_on:
       - interface
 {% endif %}
+{% endif %}

--- a/roles/openstack-stack/templates/heat_stack_server.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server.yaml.j2
@@ -61,20 +61,24 @@ parameters:
     label: Net name
     description: Net name
 
+{% if not provider_network %}
   subnet:
     type: string
     label: Subnet ID
     description: Subnet resource
+{% endif %}
 
   secgrp:
     type: comma_delimited_list
     label: Security groups
     description: Security group resources
 
+{% if not provider_network %}
   floating_network:
     type: string
     label: Floating network
     description: Network to allocate floating IP from
+{% endif %}
 
   availability_zone:
     type: string
@@ -117,7 +121,11 @@ outputs:
         - server
         - addresses
         - { get_param: net_name }
+{% if provider_network %}
+        - 0
+{% else %}
         - 1
+{% endif %}
         - addr
 
 resources:
@@ -147,15 +155,19 @@ resources:
     type: OS::Neutron::Port
     properties:
       network: { get_param: net }
+{% if not provider_network %}
       fixed_ips:
         - subnet: { get_param: subnet }
+{% endif %}
       security_groups: { get_param: secgrp }
 
+{% if not provider_network %}
   floating-ip:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: { get_param: floating_network }
       port_id: { get_resource: port }
+{% endif %}
 
 {% if not ephemeral_volumes|default(false)|bool %}
   cinder_volume:

--- a/roles/static_inventory/tasks/openstack.yml
+++ b/roles/static_inventory/tasks/openstack.yml
@@ -24,6 +24,15 @@
       when:
         - refresh_inventory|bool
 
+    - name: set_fact for openstack inventory nodes with provider network
+      set_fact:
+        registered_nodes_floating: "{{ (registered_nodes_output.stdout | from_json) | json_query(q) }}"
+      vars:
+        q: "[] | [?metadata.clusterid=='{{stack_name}}'] | [?public_v4=='']"
+      when:
+        - refresh_inventory|bool
+        - openstack_provider_network_name|default(None)
+
     - name: Add cluster nodes w/o floating IPs to inventory
       with_items: "{{ registered_nodes|difference(registered_nodes_floating) }}"
       add_host:
@@ -49,7 +58,14 @@
       add_host:
         name: '{{ item.name }}'
         groups: '{{ item.metadata.group }}'
-        ansible_host: "{% if use_bastion|bool %}{{ item.name }}{% else %}{{ item.public_v4 }}{% endif %}"
+        ansible_host: >-
+          {% if use_bastion|bool -%}
+          {{ item.name }}
+          {%- elif openstack_provider_network_name|default(None) -%}
+          {{ item.private_v4 }}
+          {%- else -%}
+          {{ item.public_v4 }}
+          {%- endif %}
         ansible_fqdn: '{{ item.name }}'
         ansible_user: '{{ ssh_user }}'
         ansible_private_key_file: '{{ private_ssh_key }}'
@@ -57,7 +73,12 @@
         private_v4: >-
           {% set node = registered_nodes | json_query("[?name=='" + item.name + "']") -%}
           {{ node[0].addresses[openstack_private_network|quote][0].addr }}
-        public_v4: '{{ item.public_v4 }}'
+        public_v4: >-
+          {% if openstack_provider_network_name|default(None) -%}
+          {{ item.private_v4 }}
+          {%- else -%}
+          {{ item.public_v4 }}
+          {%- endif %}
 
     - name: Add bastion node to inventory
       add_host:


### PR DESCRIPTION
#### What does this PR do?
This adds a new option `openstack_provider_network_name` which will take
a name of an existing network and put the servers there. It will also
prevent creating floating IP addresses as the provider network's IPs
should already be accessible without any additional routing required.

Fixes #622

#### How should this be manually tested?
You need an openstack with a provider network set up. Alternatively, you can create a new Neutron network, create a server in the network, SSH in and run the deployment from there.

1. Set `openstack_provider_network_name` to the name of your provider network in `inventory/group_vars/all.yml`
2. Comment out the `openstack_external_network_name` and `openstack_private_network_name` options in `all.yml`
3. Run the `provision.yaml` playbook

* Verify that no new Neutron network or subnet were created.
* Verify that all the Nova servers were placed in the existing provider network.
* Verify that none of the servers have a floating IP address assigned

4. Either update the provider subnet's `dns_nameservers` option (by: `openstack subnet set --dns-nameserver`) or edit `/etc/resolv.conf` on each node to make sure the nodes use the provisioned DNS
5. Install openshift with the openshift-ansible playbooks
6.  Run a source-to-image workload and verify that the image gets created, pushed to the registry and the pod is accessible via its route (e.g.: `oc new-app --template=cakephp-mysql-example`)

#### Is there a relevant Issue open for this?
#622 

#### Who would you like to review this?
cc: @ggillies @rlopez133  @bogdando PTAL
