### PR TITLE
Add Azure "E" VM sizes to templates

### DIFF
--- a/reference-architecture/azure-ansible/3.5/allinone.json
+++ b/reference-architecture/azure-ansible/3.5/allinone.json
@@ -60,6 +60,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -259,6 +271,42 @@
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_D14_v2" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64s_v3" : {
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_G1" : {

--- a/reference-architecture/azure-ansible/3.5/azuredeploy.json
+++ b/reference-architecture/azure-ansible/3.5/azuredeploy.json
@@ -76,6 +76,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -135,6 +147,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -194,6 +218,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -419,6 +455,42 @@
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_D14_v2" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64s_v3" : {
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_G1" : {

--- a/reference-architecture/azure-ansible/3.6/allinone.json
+++ b/reference-architecture/azure-ansible/3.6/allinone.json
@@ -60,6 +60,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -259,6 +271,42 @@
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_D14_v2" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64s_v3" : {
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_G1" : {

--- a/reference-architecture/azure-ansible/3.6/azuredeploy.json
+++ b/reference-architecture/azure-ansible/3.6/azuredeploy.json
@@ -76,6 +76,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -135,6 +147,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -194,6 +218,18 @@
         "Standard_D12_v2",
         "Standard_D13_v2",
         "Standard_D14_v2",
+        "Standard_E2_v3",
+        "Standard_E4_v3",
+        "Standard_E8_v3",
+        "Standard_E16_v3",
+        "Standard_E32_v3",
+        "Standard_E64_v3",
+        "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_E8s_v3",
+        "Standard_E16s_v3",
+        "Standard_E32s_v3",
+        "Standard_E64s_v3",
         "Standard_G1",
         "Standard_G2",
         "Standard_G3",
@@ -419,6 +455,42 @@
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_D14_v2" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E2s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E4s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E8s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E16s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E32s_v3" : {
+        "storageAccountType" : "Standard_LRS"
+      },
+      "Standard_E64s_v3" : {
         "storageAccountType" : "Standard_LRS"
       },
       "Standard_G1" : {


### PR DESCRIPTION
#### What does this PR do?
Add Azure "E" instances as selectable VM sizes to templates.

#### How should this be manually tested?
Choose one of the newly added E or ES VM sizes when filling out the template form on Azure platform. Expected result: The VMs have the selected profile.

#### Is there a relevant Issue open for this?
No relevant issues.

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
