### PR TITLE
Point openshift_master_cluster_public_hostname at master or lb if defined

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -295,6 +295,15 @@ variables for the `inventory/group_vars/OSEv3.yml`, `all.yml`:
     deployment_type: origin
     openshift_deployment_type: "{{ deployment_type }}"
 
+#### Setting a custom entrypoint
+
+In order to set a custom entrypoint, update `openshift_master_cluster_public_hostname`
+
+    openshift_master_cluster_public_hostname: api.openshift.example.com
+
+Note than an empty hostname does not work, so if your domain is `openshift.example.com`,
+you cannot set this value to simply `openshift.example.com`.
+
 ### Configure static inventory and access via a bastion node
 
 Example inventory variables:

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -50,6 +50,22 @@
   with_items: "{{ groups['infra_hosts'] }}"
   when: hostvars[item]['public_v4'] is defined
 
+- name: "Add public master cluster hostname records to the public A records"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
+  with_items: "{{ groups['cluster_hosts'] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - "{{ hostvars['localhost'].openstack_num_masters == 1 }}"
+
+- name: "Add public master cluster hostname records to the public A records"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
+  with_items: "{{ groups['cluster_hosts'] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - "{{ hostvars['localhost'].openstack_num_masters > 1 }}"
+
 - name: "Set the public DNS server details to use the external value (if provided)"
   set_fact:
     nsupdate_server_public: "{{ external_nsupdate_keys['public']['server'] }}"

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -9,6 +9,20 @@
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_app_domain, 'ip': hostvars[item]['private_v4'] } ] }}"
   with_items: "{{ groups['infra_hosts'] }}"
 
+- name: "Add public master cluster hostname records to the private A records (single master)"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].private_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters == 1
+
+- name: "Add public master cluster hostname records to the private A records (multi-master)"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].private_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters > 1
+
 - name: "Set the private DNS server to use the external value (if provided)"
   set_fact:
     nsupdate_server_private: "{{ external_nsupdate_keys['private']['server'] }}"

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -52,16 +52,14 @@
 
 - name: "Add public master cluster hostname records to the public A records (single master)"
   set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
-  with_items: "{{ groups['cluster_hosts'] }}"
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openstack_num_masters == 1
 
 - name: "Add public master cluster hostname records to the public A records (multi-master)"
   set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
-  with_items: "{{ groups['cluster_hosts'] }}"
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openstack_num_masters > 1

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -56,7 +56,7 @@
   with_items: "{{ groups['cluster_hosts'] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - "{{ openstack_num_masters == 1 }}"
+    - openstack_num_masters == 1
 
 - name: "Add public master cluster hostname records to the public A records (multi-master)"
   set_fact:
@@ -64,7 +64,7 @@
   with_items: "{{ groups['cluster_hosts'] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - "{{ openstack_num_masters > 1 }}"
+    - openstack_num_masters > 1
 
 - name: "Set the public DNS server details to use the external value (if provided)"
   set_fact:

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -50,21 +50,21 @@
   with_items: "{{ groups['infra_hosts'] }}"
   when: hostvars[item]['public_v4'] is defined
 
-- name: "Add public master cluster hostname records to the public A records"
+- name: "Add public master cluster hostname records to the public A records (single master)"
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - "{{ hostvars['localhost'].openstack_num_masters == 1 }}"
+    - "{{ openstack_num_masters == 1 }}"
 
-- name: "Add public master cluster hostname records to the public A records"
+- name: "Add public master cluster hostname records to the public A records (multi-master)"
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[groups.masters[0]].openshift_master_cluster_public_hostname, 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - "{{ hostvars['localhost'].openstack_num_masters > 1 }}"
+    - "{{ openstack_num_masters > 1 }}"
 
 - name: "Set the public DNS server details to use the external value (if provided)"
   set_fact:


### PR DESCRIPTION
#### What does this PR do?
If openshift_master_cluster_public_hostname is defined, then create a DNS entry that points it at the master (single master) or a load balancer (multi-master)

#### How should this be manually tested?
Specify a fun value for openshift_master_cluster_public_hostname in OSEv3.yml, and re-run the provisioning playbook; make sure your DNS is update and ping the hostname. It should resolve to the same IP as your master/load balancer node

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic @bogdando @Tlacenka  PTAL
