### PR TITLE
[WIP] Add flannel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ ansible.log
 static-inventory
 *.retry
 roles/infra-ansible/
+roles/openshift-ansible/

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -145,6 +145,28 @@ via the public IP of the server. You can not send updates via the private
 IP yet. This forces the in-stack private server to have a floating IP.
 See also the [security notes](#security-notes)
 
+#### Flannel networking
+
+In order to configure the
+[flannel networking](https://docs.openshift.com/container-platform/3.6/install_config/configuring_sdn.html#using-flannel),
+uncomment and adjust the appropriate `inventory/group_vars/OSEv3.yml` group vars.
+Note that the `osm_cluster_network_cidr` must not overlap with the default
+Docker bridge subnet of 172.17.0.0/16. Or you should change the docker0 default
+CIDR range otherwise. For example, by adding `--bip=192.168.2.1/24` to
+`DOCKER_NETWORK_OPTIONS` located in `/etc/sysconfig/docker-network`.
+
+Also note that the flannel network will be provisioned on a separate isolated Neutron
+subnet defined from `osm_cluster_network_cidr` and having ports security disabled.
+Use the `openstack_private_data_network_name` variable to define the network
+name for the heat stack resource. Keep in mind that the external authoritative DNS
+server's acl must allow the given `osm_cluster_network_cidr` as well. For provisioned
+in-stack DNS servers, this is configred automatically.
+
+After the cluster deployment done, you should run an additional post installation
+step for flannel and docker iptables configuration:
+
+   ansible-playbook openshift-ansible-contrib/playbooks/provisioning/openstack/post-install.yml
+
 #### Other configuration variables
 
 `openstack_ssh_key` is a Nova keypair - you can see your keypairs with

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -158,9 +158,7 @@ CIDR range otherwise. For example, by adding `--bip=192.168.2.1/24` to
 Also note that the flannel network will be provisioned on a separate isolated Neutron
 subnet defined from `osm_cluster_network_cidr` and having ports security disabled.
 Use the `openstack_private_data_network_name` variable to define the network
-name for the heat stack resource. Keep in mind that the external authoritative DNS
-server's acl must allow the given `osm_cluster_network_cidr` as well. For provisioned
-in-stack DNS servers, this is configred automatically.
+name for the heat stack resource.
 
 After the cluster deployment done, you should run an additional post installation
 step for flannel and docker iptables configuration:

--- a/playbooks/provisioning/openstack/galaxy-requirements.yaml
+++ b/playbooks/provisioning/openstack/galaxy-requirements.yaml
@@ -4,3 +4,7 @@
 # From 'infra-ansible'
 - src: https://github.com/redhat-cop/infra-ansible
   version: master
+
+# From 'openshift-ansible'
+- src: https://github.com/openshift/openshift-ansible
+  version: master

--- a/playbooks/provisioning/openstack/post-install.yml
+++ b/playbooks/provisioning/openstack/post-install.yml
@@ -3,16 +3,55 @@
   gather_facts: False
   become: True
   tasks:
+    - name: Save iptables rules to a backup file
+      when: openshift_use_flannel|default(False)|bool
+      shell: iptables-save > /etc/sysconfig/iptables.orig-$(date +%Y%m%d%H%M%S)
+
+# Enable iptables service on app nodes to persist custom rules (flannel SDN)
+# FIXME(bogdando) w/a https://bugzilla.redhat.com/show_bug.cgi?id=1490820
+- hosts: app
+  gather_facts: False
+  become: True
+  vars:
+    os_firewall_allow:
+      - service: dnsmasq tcp
+        port: 53/tcp
+      - service: dnsmasq udp
+        port: 53/udp
+  tasks:
+    - when: openshift_use_flannel|default(False)|bool
+      block:
+        - include_role:
+            name: openshift-ansible/roles/os_firewall
+        - include_role:
+            name: openshift-ansible/roles/lib_os_firewall
+        - name: set allow rules for dnsmasq
+          os_firewall_manage_iptables:
+            name: "{{ item.service }}"
+            action: add
+            protocol: "{{ item.port.split('/')[1] }}"
+            port: "{{ item.port.split('/')[0] }}"
+          with_items: "{{ os_firewall_allow }}"
+
+- hosts: OSEv3
+  gather_facts: False
+  become: True
+  tasks:
     - name: Apply post-install iptables hacks for Flannel SDN (the best effort)
       when: openshift_use_flannel|default(False)|bool
       block:
-        - name: Save iptables rules to a backup file
-          shell: iptables-save > /etc/sysconfig/iptables.orig-$(date +%Y%m%d%H%M%S)
+        - name: set allow/masquerade rules for for flannel/docker
+          shell: >-
+            (iptables-save | grep -q custom-flannel-docker-1) ||
+            iptables -A DOCKER -w
+            -p all -j ACCEPT
+            -m comment --comment "custom-flannel-docker-1";
+            (iptables-save | grep -q custom-flannel-docker-2) ||
+            iptables -t nat -A POSTROUTING -w
+            -o {{flannel_interface|default('eth1')}}
+            -m comment --comment "custom-flannel-docker-2"
+            -j MASQUERADE
 
-        - name: Add iptables rules for flannel SDN and docker
-          shell: >
-            iptables -I DOCKER 1 -w -p all -j ACCEPT;
-            iptables -t nat -I POSTROUTING 1 -w -o {{flannel_interface|default('eth1')}} -j MASQUERADE
-
-        - name: Persist modified iptables rules
-          shell: iptables-save > /etc/sysconfig/iptables
+        # NOTE(bogdando) the rules will not be restored, when iptables service unit is disabled & masked
+        - name: Persist in-memory iptables rules (w/o dynamic KUBE rules)
+          shell: iptables-save | grep -v KUBE > /etc/sysconfig/iptables

--- a/playbooks/provisioning/openstack/post-install.yml
+++ b/playbooks/provisioning/openstack/post-install.yml
@@ -1,0 +1,18 @@
+---
+- hosts: OSEv3
+  gather_facts: False
+  become: True
+  tasks:
+    - name: Apply post-install iptables hacks for Flannel SDN (the best effort)
+      when: openshift_use_flannel|default(False)|bool
+      block:
+        - name: Save iptables rules to a backup file
+          shell: iptables-save > /etc/sysconfig/iptables.orig-$(date +%Y%m%d%H%M%S)
+
+        - name: Add iptables rules for flannel SDN and docker
+          shell: >
+            iptables -I DOCKER 1 -w -p all -j ACCEPT;
+            iptables -t nat -I POSTROUTING 1 -w -o {{flannel_interface|default('eth1')}} -j MASQUERADE
+
+        - name: Persist modified iptables rules
+          shell: iptables-save > /etc/sysconfig/iptables

--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -76,6 +76,16 @@
   hosts: OSEv3
   gather_facts: true
   become: true
+  vars:
+    interface: "{{ flannel_interface|default('eth1') }}"
+    interface_file: /etc/sysconfig/network-scripts/ifcfg-{{ interface }}
+    interface_config:
+      DEVICE: "{{ interface }}"
+      TYPE: Ethernet
+      BOOTPROTO: dhcp
+      ONBOOT: 'yes'
+      DEFTROUTE: 'no'
+      PEERDNS: 'no'
   pre_tasks:
     - name: "Include DNS configuration to ensure proper name resolution"
       lineinfile:
@@ -83,6 +93,21 @@
         dest: /etc/sysconfig/network
         regexp: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
         line: "IP4_NAMESERVERS={{ hostvars['localhost'].private_dns_server }}"
+    - name: "Configure the flannel interface options"
+      when: openshift_use_flannel|default(False)|bool
+      block:
+        - file:
+            dest: "{{ interface_file }}"
+            state: touch
+            mode: 0644
+            owner: root
+            group: root
+        - lineinfile:
+            state: present
+            dest: "{{ interface_file }}"
+            regexp: "{{ item.key }}="
+            line: "{{ item.key }}={{ item.value }}"
+          with_dict: "{{ interface_config }}"
   roles:
     - node-network-manager
 

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -53,5 +53,7 @@ openshift_override_hostname_check: true
 ansible_become: true
 
 # # Flannel networking
+#osm_cluster_network_cidr: 10.128.0.0/14
 #openshift_use_openshift_sdn: false
 #openshift_use_flannel: true
+#flannel_interface: eth1

--- a/roles/dns-views/tasks/main.yml
+++ b/roles/dns-views/tasks/main.yml
@@ -4,11 +4,6 @@
     acl_list: "{{ acl_list | default([]) + [ (hostvars[item]['private_v4'] + '/32') ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
 
-- name: "Update ACL list for DNS server with custom osm_cluster_network"
-  set_fact:
-    acl_list: "{{ acl_list | default([]) + [osm_cluster_network_cidr] }}"
-  when: osm_cluster_network_cidr is defined
-
 - name: "Generate the private view"
   set_fact:
     private_named_view:

--- a/roles/dns-views/tasks/main.yml
+++ b/roles/dns-views/tasks/main.yml
@@ -4,6 +4,11 @@
     acl_list: "{{ acl_list | default([]) + [ (hostvars[item]['private_v4'] + '/32') ] }}"
   with_items: "{{ groups['cluster_hosts'] }}"
 
+- name: "Update ACL list for DNS server with custom osm_cluster_network"
+  set_fact:
+    acl_list: "{{ acl_list | default([]) + [osm_cluster_network_cidr] }}"
+  when: osm_cluster_network_cidr is defined
+
 - name: "Generate the private view"
   set_fact:
     private_named_view:


### PR DESCRIPTION
#### What does this PR do?

* Document flannel options. See the [updated ref arch](https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/deploying_and_managing_red_hat_openshift_container_platform_3.6_on_red_hat_openstack_platform_10/#flannel_considerations) for more details.
* Provision a dedicated isolated neutron subnet for the flannel network and disable ports security on it.
* Add openshift-ansible as a galaxy dependency module.
* Create a post-install playbook for Flannel SDN post deployment configs
* Use the os_firewall role to configure iptables and apply rules required for Flannel SDN to function.
* Configure and enable the masked iptables service on the app nodes for Flannel SDN. Keep it as is, disabled and masked, for other nodes groups.

#### How should this be manually tested?
Uncomment flannel options in OSEv3 group vars.
Provision an env, deploy from `openshift-ansible-3.7.0-0.127.0-69-gc16d16d` or later (it must contain the flannel fixes `98db8ec` and `fdc61b8`), and run e2e, it should pass.
Verify that iptables rules added by post-install playbook are persistent across node reboots and iptables services restarts.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic @e-minguez  PTAL
