### PR TITLE
Add ability to support custom api and console ports

### DIFF
--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -287,6 +287,10 @@ resources:
           port_range_max: {{ openshift_master_api_port|default(8443) }}
         - direction: ingress
           protocol: tcp
+          port_range_min: {{ openshift_master_console_port|default(8443) }}
+          port_range_max: {{ openshift_master_console_port|default(8443) }}
+        - direction: ingress
+          protocol: tcp
           port_range_min: 8053
           port_range_max: 8053
         - direction: ingress

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -188,8 +188,12 @@ resources:
           port_range_max: 4001
         - direction: ingress
           protocol: tcp
-          port_range_min: 8443
-          port_range_max: 8444
+          port_range_min: {{ openshift_master_api_port|default(8443) }}
+          port_range_max: {{ openshift_master_api_port|default(8443) }}
+        - direction: ingress
+          protocol: tcp
+          port_range_min: {{ openshift_master_console_port|default(8443) }}
+          port_range_max: {{ openshift_master_console_port|default(8443) }}
         - direction: ingress
           protocol: tcp
           port_range_min: 8053
@@ -279,8 +283,8 @@ resources:
           port_range_max: 4001
         - direction: ingress
           protocol: tcp
-          port_range_min: 8443
-          port_range_max: 8444
+          port_range_min: {{ openshift_master_api_port|default(8443) }}
+          port_range_max: {{ openshift_master_api_port|default(8443) }}
         - direction: ingress
           protocol: tcp
           port_range_min: 8053


### PR DESCRIPTION
#### What does this PR do?
Updated heat templates to accommodate customized master API ports.

#### How should this be manually tested?
Add the following to `inventory/group_vars/all.yml`:

```
openshift_master_api_port: 443
openshift_master_console_port: 443
```
And provision an Openstack cluster

#### Is there a relevant Issue open for this?
n/s

#### Who would you like to review this?
cc: @tomassedovic @bogdando @oybed 
