### PR TITLE
auto create the storage class based on vmware_datacenter

### DIFF
--- a/reference-architecture/vmware-ansible/playbooks/openshift-configure.yaml
+++ b/reference-architecture/vmware-ansible/playbooks/openshift-configure.yaml
@@ -8,3 +8,11 @@
   - instance-groups
 
 - include: ../../../playbooks/empty-dir-quota.yaml
+
+- hosts: single_master
+  gather_facts: yes
+  vars_files:
+  - vars/main.yaml
+  roles:
+  - instance-groups
+  - storage-class-configure

--- a/reference-architecture/vmware-ansible/playbooks/roles/storage-class-configure/tasks/main.yaml
+++ b/reference-architecture/vmware-ansible/playbooks/roles/storage-class-configure/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+- name: Copy cloud provider storage class file
+  template:
+    src: cloud-provider-storage-class.yaml.j2
+    dest: ~/cloud-provider-storage-class.yaml
+
+- name: Copy cloud provider storage class file to single master
+  fetch:
+    src: ~/cloud-provider-storage-class.yaml
+    dest: ~/cloud-provider-storage-class.yaml
+    flat: yes
+
+- name: Switch to default project
+  command: oc project default
+
+- name: Check to see if storage class is already created
+  command: "oc get storageclass"
+  register: storage_class
+
+- name: Create storage class
+  command: "oc create -f ~/cloud-provider-storage-class.yaml"
+  when: "'{{ vmware_datastore }}' not in storage_class.stdout"

--- a/reference-architecture/vmware-ansible/playbooks/roles/storage-class-configure/templates/cloud-provider-storage-class.yaml.j2
+++ b/reference-architecture/vmware-ansible/playbooks/roles/storage-class-configure/templates/cloud-provider-storage-class.yaml.j2
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: "{{ vmware_datastore }}"
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: zeroedthick
+    datastore: "{{ vmware_datastore }}"


### PR DESCRIPTION
#### What does this PR do?
auto create the storage class based on vmware_datacenter

#### How should this be manually tested?
cd ~; git clone -b vmw-3.6;cd ~/openshift-ansible-contrib/reference-architecture/vmware-ansible
./ocp-on-vmware.py --create_inventory; ./ocp-on-vmware.py --create_ocp_vars; ./ocp-on-vmware.py

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @rlopez133 @cooktheryan @e-minguez PTAL
