### PR TITLE
Empty ssh

### DIFF
--- a/ci/openstack/install-openshift.sh
+++ b/ci/openstack/install-openshift.sh
@@ -17,15 +17,15 @@ export INVENTORY="$PWD/playbooks/provisioning/openstack/sample-inventory"
 
 echo INSTALL OPENSHIFT
 
-ansible-playbook --become --timeout 180 --user openshift --private-key ~/.ssh/id_rsa -i "$INVENTORY" ../openshift-ansible/playbooks/byo/config.yml -e @extra-vars.yaml
+ansible-playbook --become --timeout 180 --user openshift -i "$INVENTORY" ../openshift-ansible/playbooks/byo/config.yml -e @extra-vars.yaml
 
 
 echo Waiting for the router to come up
 for i in $(seq 15); do
-    if ansible -i "$INVENTORY" masters --user openshift --private-key ~/.ssh/id_rsa -m shell -a 'oc get pod | grep -v deploy | grep router | grep Running'; then
+    if ansible -i "$INVENTORY" masters --user openshift -m shell -a 'oc get pod | grep -v deploy | grep router | grep Running'; then
         echo Router is running
         break
-    elif ansible -i "$INVENTORY" masters --user openshift --private-key ~/.ssh/id_rsa -m shell -a 'oc get pod | grep -v deploy | grep router | grep Failed'; then
+    elif ansible -i "$INVENTORY" masters --user openshift -m shell -a 'oc get pod | grep -v deploy | grep router | grep Failed'; then
         echo Router failed
         break
     else
@@ -36,10 +36,10 @@ done
 
 echo Waiting for the docker-registry to come up
 for i in $(seq 15); do
-    if ansible -i "$INVENTORY" masters --user openshift --private-key ~/.ssh/id_rsa -m shell -a 'oc get pod | grep docker-registry | grep Running'; then
+    if ansible -i "$INVENTORY" masters --user openshift -m shell -a 'oc get pod | grep docker-registry | grep Running'; then
         echo Registry is running
         break
-    elif ansible -i "$INVENTORY" masters --user openshift --private-key ~/.ssh/id_rsa -m shell -a 'oc get pod | grep docker-registry | grep Failed'; then
+    elif ansible -i "$INVENTORY" masters --user openshift -m shell -a 'oc get pod | grep docker-registry | grep Failed'; then
         echo Registry failed
         break
     else
@@ -49,10 +49,10 @@ for i in $(seq 15); do
 done
 
 echo oc get nodes --show-labels:
-ansible -i "$INVENTORY" masters --user openshift --private-key ~/.ssh/id_rsa -m command -a 'oc get nodes --show-labels'
+ansible -i "$INVENTORY" masters --user openshift -m command -a 'oc get nodes --show-labels'
 
 echo oc status -v:
-ansible -i "$INVENTORY" masters --user openshift --private-key ~/.ssh/id_rsa -m command -a 'oc status -v'
+ansible -i "$INVENTORY" masters --user openshift -m command -a 'oc status -v'
 
 echo oc get all:
-ansible -i "$INVENTORY" masters --user openshift --private-key ~/.ssh/id_rsa -m command -a 'oc get all'
+ansible -i "$INVENTORY" masters --user openshift -m command -a 'oc get all'

--- a/ci/openstack/provision.sh
+++ b/ci/openstack/provision.sh
@@ -28,7 +28,6 @@ PUBLIC_IP="$(curl --silent https://api.ipify.org)"
 
 
 cat << EOF >> extra-vars.yaml
-openstack_ssh_public_key: $KEYPAIR_NAME
 openstack_external_network_name: "38.145.32.0/22"
 openstack_default_image_name: "CentOS-7-x86_64-GenericCloud-1703"
 openstack_num_nodes: 1
@@ -68,7 +67,7 @@ echo
 echo INSTALL OPENSHIFT
 
 ansible-galaxy install -r playbooks/provisioning/openstack/galaxy-requirements.yaml -p roles
-ansible-playbook --timeout 180 --user openshift --private-key ~/.ssh/id_rsa -i "$INVENTORY" playbooks/provisioning/openstack/provision.yaml -e @extra-vars.yaml
+ansible-playbook --timeout 180 --user openshift -i "$INVENTORY" playbooks/provisioning/openstack/provision.yaml -e @extra-vars.yaml
 
 echo
 echo INVENTORY hosts file:

--- a/ci/openstack/provision.sh
+++ b/ci/openstack/provision.sh
@@ -28,6 +28,7 @@ PUBLIC_IP="$(curl --silent https://api.ipify.org)"
 
 
 cat << EOF >> extra-vars.yaml
+openstack_ssh_public_key: $KEYPAIR_NAME
 openstack_external_network_name: "38.145.32.0/22"
 openstack_default_image_name: "CentOS-7-x86_64-GenericCloud-1703"
 openstack_num_nodes: 1

--- a/playbooks/provisioning/openstack/provision-openstack.yml
+++ b/playbooks/provisioning/openstack/provision-openstack.yml
@@ -11,7 +11,7 @@
     - role: static_inventory
       when: openstack_inventory|default('static') == 'static'
       inventory_path: "{{ openstack_inventory_path|default(inventory_dir) }}"
-      private_ssh_key: "{{ openstack_private_ssh_key|default('~/.ssh/id_rsa') }}"
+      private_ssh_key: "{{ openstack_private_ssh_key|default('') }}"
       ssh_config_path: "{{ openstack_ssh_config_path|default('/tmp/ssh.config.openshift.ansible' + '.' + stack_name) }}"
       ssh_user: "{{ ansible_user }}"
 

--- a/roles/static_inventory/templates/inventory.j2
+++ b/roles/static_inventory/templates/inventory.j2
@@ -12,7 +12,7 @@
 %} public_v4={{ hostvars[host]['public_v4'] }}{% endif %}
 {% if 'ansible_user' in hostvars[host]
 %} ansible_user={{ hostvars[host]['ansible_user'] }}{% endif %}
-{% if 'ansible_private_key_file' in hostvars[host]
+{% if 'ansible_private_key_file' in hostvars[host] and hostvars[host]['ansible_private_key_file']
 %} ansible_private_key_file={{ hostvars[host]['ansible_private_key_file'] }}{% endif %}
 {% if use_bastion|bool and 'ansible_ssh_extra_args' in hostvars[host]
 %} ansible_ssh_extra_args={{ hostvars[host]['ansible_ssh_extra_args']|quote }}{% endif %} openshift_hostname={{ host }}


### PR DESCRIPTION
#### What does this PR do?
It makes the `openstack_private_ssh_key` value optional and does not set it in the static inventory if it's not present.

#### How should this be manually tested?

1. Make sure your SSH key is not in `~/.ssh/id_rsa` -- you can temporarily move it to `~/openshift-private-key` or something
2. Make sure that your `inventory/group_vars/all.yml` **does not** have the `openstack_private_ssh_key` variable set up
3. Run the provisioning playbook and pass `--private-key ~/openshift-private-key` (or whatever the path to your key is) to `ansible-playbook`
4. Verify that the generated hosts file **does not** contain the `ansible_private_key_file` values
5. Verify that the provisioning playbook passes -- in particular, the `wait_for_connection` task should succeed


#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @tzumainn @Tlacenka @celebdor  @bogdando PTAL
