### PR TITLE
Clear the previous inventory during provisioning

### DIFF
--- a/roles/static_inventory/tasks/main.yml
+++ b/roles/static_inventory/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove any existing inventory
+  file:
+    path: "{{ inventory_path }}/hosts"
+    state: absent
+
+- name: Refresh the inventory
+  meta: refresh_inventory
+
 - name: Generate in-memory inventory
   include: openstack.yml
 


### PR DESCRIPTION
#### What does this PR do?

If there was a left-over inventory from a previous run that had nodes
which were subsequently removed, these would still show up in the
Ansible's in-memory inventory and Ansible would fail trying to connect
to them.

This is because Ansible automatically loads the `inventory/hosts` file
if it exists and even if we overwrite it later, every node and group
still remains in the memory.

By removing the inventory file and and calling the `refresh_inventory`
meta task, we make sure that any left-over values are removed.


#### How should this be manually tested?

1. Run provisioning with at least 2 app nodes
2. Set the number of app nodes in `inventory/group_vars/all.yml` to `1`
3. Re-run provisioning, making sure that `inventory/hosts` is still there
4. It should succeed (before this patch, it would fail in `wait_for_connection` trying to connect to the removed nodes.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @Tlacenka @tzumainn @celebdor  @bogdando PTAL
