### PR TITLE
Make rhsm registry optional for openstack

### DIFF
--- a/playbooks/provisioning/openstack/pre-install.yml
+++ b/playbooks/provisioning/openstack/pre-install.yml
@@ -9,7 +9,7 @@
 - hosts: OSEv3
   become: true
   roles:
-    - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
+    - { role: subscription-manager, when: hostvars.localhost.rhsm_register|default(False), tags: 'subscription-manager', ansible_sudo: true }
     - { role: docker, tags: 'docker' }
     - { role: openshift-prep, tags: 'openshift-prep' }
 

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -77,8 +77,9 @@ docker_volume_size: "15"
 
 openstack_subnet_prefix: "192.168.99"
 
-# # Red Hat subscription
-rhsm_register: False
+## Red Hat subscription defaults to false which means we will not attempt to
+## subscribe the nodes
+#rhsm_register: False
 
 # # Using Red Hat Satellite:
 #rhsm_register: True


### PR DESCRIPTION
#### What does this PR do?
This makes the `rhsm_register` value optional, defaulting to false. We used to behave that way but regressed.

#### How should this be manually tested?
1. Remove the `rhsm_register` value from your inventory
2. Provision openstack
3. Verify the provisioning succeeds

Without this patch, it would fail.

Note that this also updates the sample inventory so the end to end CI will exercise this change, too.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @tzumainn @Tlacenka @celebdor  @bogdando PTAL
