### PR TITLE
Use Ansible stable 2.3 instead of 2.2

### DIFF
--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -37,7 +37,7 @@ $ yum -y install python-pip git python2-boto \
                  python-netaddr python-httplib2 python-devel \
                  gcc libffi-devel openssl-devel python2-boto3 \
                  python-click python-six pyOpenSSL
-$ pip install git+https://github.com/ansible/ansible.git@stable-2.2
+$ pip install git+https://github.com/ansible/ansible.git@stable-2.3
 $ mkdir -p /usr/share/ansible/openshift-ansible
 $ git clone https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible
 ```


### PR DESCRIPTION
#### What does this PR do?
Use Ansible 2.3 instead of 2.2 to avoid a block attribute syntax error during origin greenfield deployments.

#### How should this be manually tested?
Using a fresh system/VM, install Origin on AWS using ```aws-ansible``` for a greenfield deployment, taking care to follow the pre-reqs exactly.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL