### PR TITLE
load balancer formatting fix

### DIFF
--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -577,14 +577,14 @@ resources:
           secgrp:
             - { get_resource: lb-secgrp }
             - { get_resource: common-secgrp }
-    {% if not provider_network %}
+{% if not provider_network %}
           floating_network: {{ external_network }}
-    {% endif %}
+{% endif %}
           volume_size: {{ lb_volume_size }}
-    {% if not provider_network %}
+{% if not provider_network %}
     depends_on:
       - interface
-    {% endif %}
+{% endif %}
 {% endif %}
 
   masters:


### PR DESCRIPTION
#### What does this PR do?
Currently the heat stack template has incorrect formatting when a load balancer is needed. This PR fixes that issue.

#### How should this be manually tested?
Specify 2 master nodes in all.yml so that a load balancer is provisioned. Run the openstack provisioning playbook without this fix; there should be a formatting error when ansible tries to create the heat stack. Re-run with this fix, and provisioning should finish without errors.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic @bogdando  PTAL
