### PR TITLE
Set Ansible version in openstack CI for 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
 env:
   global:
     - CI_CONCURRENT_JOBS=1
-    - OPENSHIFT_ANSIBLE_COMMIT=
+    - OPENSHIFT_ANSIBLE_COMMIT=openshift-ansible-3.6.22-1
   matrix:
     - RUN_OPENSTACK_CI=false
     - RUN_OPENSTACK_CI=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
 env:
   global:
     - CI_CONCURRENT_JOBS=1
-    - OPENSHIFT_ANSIBLE_COMMIT=master
+    - OPENSHIFT_ANSIBLE_COMMIT=
   matrix:
     - RUN_OPENSTACK_CI=false
     - RUN_OPENSTACK_CI=true

--- a/ci/openstack/install.sh
+++ b/ci/openstack/install.sh
@@ -19,4 +19,4 @@ git checkout "${OPENSHIFT_ANSIBLE_COMMIT:-master}"
 git status
 cd ../openshift-ansible-contrib
 
-pip install ansible shade dnspython python-openstackclient python-heatclient
+pip install ansible==2.3.2.0 shade dnspython python-openstackclient python-heatclient

--- a/ci/openstack/install.sh
+++ b/ci/openstack/install.sh
@@ -17,6 +17,7 @@ git clone https://github.com/openshift/openshift-ansible ../openshift-ansible
 cd ../openshift-ansible
 git checkout "${OPENSHIFT_ANSIBLE_COMMIT:-master}"
 git status
+git show --no-patch
 cd ../openshift-ansible-contrib
 
 pip install ansible==2.3.2.0 shade dnspython python-openstackclient python-heatclient

--- a/ci/openstack/provision.sh
+++ b/ci/openstack/provision.sh
@@ -73,12 +73,3 @@ ansible-playbook --timeout 180 --user openshift -i "$INVENTORY" playbooks/provis
 echo
 echo INVENTORY hosts file:
 cat $INVENTORY/hosts
-
-
-echo SET UP DNS
-
-cp /etc/resolv.conf resolv.conf.orig
-DNS_IP=$(openstack server show dns-0.$ENV_ID.example.com --format value --column addresses | awk '{print $2}')
-grep -v '^nameserver' resolv.conf.orig > resolv.conf.openshift
-echo nameserver "$DNS_IP" >> resolv.conf.openshift
-sudo cp resolv.conf.openshift /etc/resolv.conf

--- a/ci/openstack/teardown.sh
+++ b/ci/openstack/teardown.sh
@@ -8,5 +8,8 @@ if [ "${RUN_OPENSTACK_CI:-}" != "true" ]; then
     exit
 fi
 
+echo RESTORING DNS
+sudo cp resolv.conf.orig /etc/resolv.conf
+
 openstack keypair delete "$KEYPAIR_NAME" || true
 openstack stack delete --wait --yes "$ENV_ID.example.com" || true

--- a/ci/openstack/teardown.sh
+++ b/ci/openstack/teardown.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 source ci/openstack/vars.sh
 if [ "${RUN_OPENSTACK_CI:-}" != "true" ]; then
     echo RUN_OPENSTACK_CI is set to false, skipping the openstack end to end test.
     exit
 fi
-
-echo RESTORING DNS
-sudo cp resolv.conf.orig /etc/resolv.conf
 
 openstack keypair delete "$KEYPAIR_NAME" || true
 openstack stack delete --wait --yes "$ENV_ID.example.com" || true

--- a/ci/openstack/validate.sh
+++ b/ci/openstack/validate.sh
@@ -2,11 +2,19 @@
 
 set -euox pipefail
 
+
 source ci/openstack/vars.sh
 if [ "${RUN_OPENSTACK_CI:-}" != "true" ]; then
     echo RUN_OPENSTACK_CI is set to false, skipping the openstack end to end test.
     exit
 fi
+
+echo SET UP DNS
+cp /etc/resolv.conf resolv.conf.orig
+DNS_IP=$(openstack server show dns-0.$ENV_ID.example.com --format value --column addresses | awk '{print $2}')
+grep -v '^nameserver' resolv.conf.orig > resolv.conf.openshift
+echo nameserver "$DNS_IP" >> resolv.conf.openshift
+sudo cp resolv.conf.openshift /etc/resolv.conf
 
 mkdir -p bin
 scp -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" openshift@master-0.$ENV_ID.example.com:/usr/bin/oc bin/

--- a/ci/openstack/validate.sh
+++ b/ci/openstack/validate.sh
@@ -16,6 +16,12 @@ grep -v '^nameserver' resolv.conf.orig > resolv.conf.openshift
 echo nameserver "$DNS_IP" >> resolv.conf.openshift
 sudo cp resolv.conf.openshift /etc/resolv.conf
 
+function restore_dns {
+    echo RESTORING DNS
+    sudo cp resolv.conf.orig /etc/resolv.conf
+}
+trap restore_dns EXIT
+
 mkdir -p bin
 scp -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" openshift@master-0.$ENV_ID.example.com:/usr/bin/oc bin/
 ls -alh bin


### PR DESCRIPTION
#### What does this PR do?
Ansible 2.4 just came out and it breaks our playbooks. Let's pin the end
to end CI version to 2.3 until we've figured it out.

See this log for an example of the failing CI:

https://travis-ci.org/openshift/openshift-ansible-contrib/jobs/277852616

#### How should this be manually tested?
This is a CI fix, no manual testing required. Just verify that the end to end openstack CI passed.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @tzumainn @Tlacenka  @bogdando PTAL
