### PR TITLE
Fix public master cluster DNS record when using bastion

### DIFF
--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -58,6 +58,7 @@
   become: False
   roles:
     - role: dns-records
+      use_bastion: "{{ openstack_use_bastion|default(False)|bool }}"
     - role: infra-ansible/roles/dns
 
 - name: Switch the stack subnet to the configured private DNS server

--- a/roles/dns-records/defaults/main.yml
+++ b/roles/dns-records/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+use_bastion: False

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -70,6 +70,15 @@
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openstack_num_masters == 1
+    - not use_bastion|bool
+
+- name: "Add public master cluster hostname records to the public A records (single master behind a bastion)"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.bastions[0]].public_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters == 1
+    - use_bastion|bool
 
 - name: "Add public master cluster hostname records to the public A records (multi-master)"
   set_fact:


### PR DESCRIPTION
#### What does this PR do?
When using a bastion and a single master, add the bastion node's public IP the public master's IP for the DNS record.

#### How should this be manually tested?
e2e with a single master and bastion enabled shall pass

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic @tzumainn  PTAL
