### PR TITLE
Attach additional RHN Pools (post-provision custom action)

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -511,7 +511,9 @@ If you'd like to limit the run to one particular host, you can do so as follows:
 ansible-playbook --private-key ~/.ssh/openshift -i inventory/ openshift-ansible-contrib/playbooks/provisioning/openstack/custom-actions/custom-playbook.yml -l app-node-0.openshift.example.com
 ```
 
-You can also create your own custom playbook. Here's one example that adds additional YUM repositories:
+You can also create your own custom playbook. Here are a few examples:
+
+#### Adding additional YUM repositories
 
 ```
 ---
@@ -535,13 +537,30 @@ This example runs against app nodes. The list of options include:
   - masters
   - infra_hosts
 
+#### Attaching additional RHN pools
+
+```
+---
+- hosts: cluster_hosts
+  tasks:
+  - name: Attach additional RHN pool
+    command: "/usr/bin/subscription-manager attach --pool=<pool ID>"
+    register: attach_rhn_pool_result
+    until: attach_rhn_pool_result.rc == 0
+    retries: 10
+    delay: 1
+```
+
+This playbook runs against all cluster nodes. In order to help prevent slow connectivity
+problems, the task is retried 10 times in case of initial failure.
+Note that in order for this example to work in your deployment, your servers must use the RHEL image.
+
 Please consider contributing your custom playbook back to openshift-ansible-contrib!
 
 A library of custom post-provision actions exists in `openshift-ansible-contrib/playbooks/provisioning/openstack/custom-actions`. Playbooks include:
 
-##### add-yum-repos.yml
-
-[add-yum-repos.yml](https://github.com/openshift/openshift-ansible-contrib/blob/master/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml) adds a list of custom yum repositories to every node in the cluster.
+* [add-yum-repos.yml](https://github.com/openshift/openshift-ansible-contrib/blob/master/playbooks/provisioning/openstack/custom-actions/add-yum-repos.yml): adds a list of custom yum repositories to every node in the cluster
+* [add-rhn-pools.yml](https://github.com/openshift/openshift-ansible-contrib/blob/master/playbooks/provisioning/openstack/custom-actions/add-rhn-pools.yml): attaches a list of additional RHN pools to every node in the cluster
 
 ### Install OpenShift
 

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -544,6 +544,7 @@ This example runs against app nodes. The list of options include:
 - hosts: cluster_hosts
   tasks:
   - name: Attach additional RHN pool
+    become: true
     command: "/usr/bin/subscription-manager attach --pool=<pool ID>"
     register: attach_rhn_pool_result
     until: attach_rhn_pool_result.rc == 0

--- a/playbooks/provisioning/openstack/custom-actions/add-rhn-pools.yml
+++ b/playbooks/provisioning/openstack/custom-actions/add-rhn-pools.yml
@@ -4,6 +4,7 @@
     rhn_pools: []
   tasks:
   - name: Attach additional RHN pools
+    become: true
     with_items: "{{ rhn_pools }}"
     command: "/usr/bin/subscription-manager attach --pool={{ item }}"
     register: attach_rhn_pools_result

--- a/playbooks/provisioning/openstack/custom-actions/add-rhn-pools.yml
+++ b/playbooks/provisioning/openstack/custom-actions/add-rhn-pools.yml
@@ -1,0 +1,12 @@
+---
+- hosts: cluster_hosts
+  vars:
+    rhn_pools: []
+  tasks:
+  - name: Attach additional RHN pools
+    with_items: "{{ rhn_pools }}"
+    command: "/usr/bin/subscription-manager attach --pool={{ item }}"
+    register: attach_rhn_pools_result
+    until: attach_rhn_pools_result.rc == 0
+    retries: 10
+    delay: 1


### PR DESCRIPTION
#### What does this PR do?
This PR adds a custom post-provision action playbook to the `custom-actions` folder and describes this as an example in the provisioning `README`

#### How should this be manually tested?
1) Run the provisioning using RHEL images.
2) Find out which other pools are available by running `subscription-manager list --available` command on one of the hosts.
3) Run `add-rhn-pools` to add these new pools like so:
```
ansible-playbook -i <inventory> openshift-ansible-contrib/playbooks/provisioning/openstack/custom-actions/add-rhn-pools.yml --extra-vars '{"rhn_pools":["<pool ID>","<pool ID>"]}' 
```
4) List available pools on one of the hosts by running `subscription-manager list --consumed` and confirm that the new pools have been added. 
#### Is there a relevant Issue open for this?
--

#### Who would you like to review this?
cc: @tomassedovic @bogdando @tzumainn PTAL
