### PR TITLE
Support separate data network for Flannel SDN

### DIFF
--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -242,8 +242,13 @@ provider network directly.
 To use a provider network, set its name in `openstack_provider_network_name` in
 `inventory/group_vars/all.yml`.
 
-If you set the provider network name, the `openstack_external_network_name` and
-`openstack_private_network_name` fields will be ignored.
+When using Flannel SDN as a provider data network, set the dedicated flannel network
+name in `openstack_provider_data_network_name` as well. That network is used for
+the applications/workloads data and should be isolated from other provider networks.
+
+If you set the provider network name, the `openstack_external_network_name`,
+`openstack_private_network_name` and `openstack_private_data_network_name` fields
+will be ignored.
 
 **NOTE**: this will not update the nodes' DNS, so running openshift-ansible
 right after provisioning will fail (unless you're using an external DNS server
@@ -266,6 +271,10 @@ may want to turn off in order to speed up the provisioning tasks. This may
 be the case for development environments. When turned off, the servers will
 be provisioned omitting the ``yum update`` command. This brings security
 implications though, and is not recommended for production deployments.
+
+Flannel network used for user applications and workloads data should be
+isolated from other networks as it has Neutron ports security disabled.
+Openshift master, compute and infra nodes will be connected to that network.
 
 ##### DNS servers security options
 

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -242,18 +242,16 @@ provider network directly.
 To use a provider network, set its name in `openstack_provider_network_name` in
 `inventory/group_vars/all.yml`.
 
-When using Flannel SDN as a provider data network, set the dedicated flannel network
-name in `openstack_provider_data_network_name` as well. That network is used for
-the applications/workloads data and should be isolated from other provider networks.
-
-If you set the provider network name, the `openstack_external_network_name`,
-`openstack_private_network_name` and `openstack_private_data_network_name` fields
-will be ignored.
+If you set the provider network name, the `openstack_external_network_name` and
+`openstack_private_network_name` fields will be ignored.
 
 **NOTE**: this will not update the nodes' DNS, so running openshift-ansible
 right after provisioning will fail (unless you're using an external DNS server
 your provider network knows about). You must make sure your nodes are able to
 resolve each other by name.
+
+**NOTE**: Flannel SDN requires a dedicated containers data network and cannot
+work over a single provider network.
 
 #### Security notes
 
@@ -588,7 +586,7 @@ The `increment_by` variable is used to specify by how much the deployment should
 be scaled up (if none exists, it serves as a target number of application nodes).
 The path to `openshift-ansible` directory can be customised by the `openshift_ansible_dir`
 variable. Its value must be an absolute path to `openshift-ansible` and it cannot
-contain the '/' symbol at the end. 
+contain the '/' symbol at the end.
 
 Usage:
 

--- a/playbooks/provisioning/openstack/net_vars_check.yaml
+++ b/playbooks/provisioning/openstack/net_vars_check.yaml
@@ -1,0 +1,14 @@
+---
+- name: Check the provider network configuration
+  fail:
+    msg: "Flannel SDN requires a dedicated containers data network and can not work over a provider network"
+  when:
+    - openstack_provider_network_name is defined
+    - openstack_private_data_network_name is defined
+
+- name: Check the flannel network configuration
+  fail:
+    msg: "A dedicated containers data network is only supported with Flannel SDN"
+  when:
+    - openstack_private_data_network_name is defined
+    - not openshift_use_flannel|default(False)|bool

--- a/playbooks/provisioning/openstack/prerequisites.yml
+++ b/playbooks/provisioning/openstack/prerequisites.yml
@@ -2,6 +2,9 @@
 - hosts: localhost
   tasks:
 
+  # Sanity check of inventory variables
+  - include: net_vars_check.yaml
+
   # Check ansible
   - name: Check Ansible version
     assert:

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -46,3 +46,7 @@ openshift_override_hostname_check: true
 # NOTE(shadower): Always switch to root on the OSEv3 nodes.
 # openshift-ansible requires an explicit `become`.
 ansible_become: true
+
+# # Flannel networking
+#openshift_use_openshift_sdn: false
+#openshift_use_flannel: true

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -14,13 +14,21 @@ public_dns_nameservers: []
 
 openstack_ssh_public_key: "openshift"
 openstack_external_network_name: "public"
+# # A Neutron network name for control/management/data (user workloads)
 #openstack_private_network_name:  "openshift-ansible-{{ stack_name }}-net"
+# # A dedicated Neutron network name for data (user workloads)
+# # NOTE: this is only supported with Flannel SDN yet
+#openstack_private_data_network_name: "openshift-ansible-{{ stack_name }}-data-net"
 
-## If you want to use a provider network, set its name here.
-## NOTE: the `openstack_external_network_name` and
-## `openstack_private_network_name` options will be ignored when using a
-## provider network.
+# # If you want to use a provider network, set its name here.
+# # NOTE: the `openstack_external_network_name`, `openstack_private_network_name`
+# # and `openstack_private_data_network_name` options will be ignored when using a
+# # provider network.
+# # A provider network name for control/management/data (user workloads)
 #openstack_provider_network_name: "provider"
+# # A dedicated provider network name for data (user workloads)
+# # NOTE: this is only supported with Flannel SDN yet
+#openstack_provider_data_network_name: "provider-data"
 
 # # Used Images
 # # - set specific images for roles by uncommenting corresponding lines

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -14,21 +14,17 @@ public_dns_nameservers: []
 
 openstack_ssh_public_key: "openshift"
 openstack_external_network_name: "public"
-# # A Neutron network name for control/management/data (user workloads)
 #openstack_private_network_name:  "openshift-ansible-{{ stack_name }}-net"
-# # A dedicated Neutron network name for data (user workloads)
+# # A dedicated Neutron network name for containers data network
+# # Configures the data network to be separated from openstack_private_network_name
 # # NOTE: this is only supported with Flannel SDN yet
 #openstack_private_data_network_name: "openshift-ansible-{{ stack_name }}-data-net"
 
-# # If you want to use a provider network, set its name here.
-# # NOTE: the `openstack_external_network_name`, `openstack_private_network_name`
-# # and `openstack_private_data_network_name` options will be ignored when using a
-# # provider network.
-# # A provider network name for control/management/data (user workloads)
+## If you want to use a provider network, set its name here.
+## NOTE: the `openstack_external_network_name` and
+## `openstack_private_network_name` options will be ignored when using a
+## provider network.
 #openstack_provider_network_name: "provider"
-# # A dedicated provider network name for data (user workloads)
-# # NOTE: this is only supported with Flannel SDN yet
-#openstack_provider_data_network_name: "provider-data"
 
 # # Used Images
 # # - set specific images for roles by uncommenting corresponding lines

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -113,6 +113,22 @@ resources:
         - {{ nameserver }}
 {% endfor %}
 
+{% if openshift_use_flannel|default(False)|bool %}
+  data_net:
+    type: OS::Neutron::Net
+    properties:
+      name: openshift-ansible-{{ stack_name }}-data-net
+      port_security_enabled: false
+
+  data_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      name: openshift-ansible-{{ stack_name }}-data-subnet
+      network: { get_resource: data_net }
+      cidr: {{ osm_cluster_network_cidr|default('10.128.0.0/14') }}
+      gateway_ip: null
+{% endif %}
+
   router:
     type: OS::Neutron::Router
     properties:
@@ -618,7 +634,12 @@ resources:
           key_name:    {{ ssh_public_key }}
 {% if provider_network %}
           net:         {{ provider_network }}
-          net_name:         {{ provider_network }}
+          net_name:    {{ provider_network }}
+{% if openshift_use_flannel|default(False)|bool %}
+          attach_data_net: true
+          data_net:    {{ provider_data_network }}
+          data_net_name: {{ provider_data_network }}
+{% endif %}
 {% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
@@ -627,6 +648,12 @@ resources:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ stack_name }}
+{% if openshift_use_flannel|default(False)|bool %}
+          attach_data_net: true
+          data_net:    { get_resource: data_net }
+          data_subnet: { get_resource: data_subnet }
+          data_net_name: openshift-ansible-{{ stack_name }}-data-net
+{% endif %}
 {% endif %}
           secgrp:
 {% if openstack_flat_secgrp|default(False)|bool %}
@@ -686,7 +713,12 @@ resources:
           key_name:    {{ ssh_public_key }}
 {% if provider_network %}
           net:         {{ provider_network }}
-          net_name:         {{ provider_network }}
+          net_name:    {{ provider_network }}
+{% if openshift_use_flannel|default(False)|bool %}
+          attach_data_net: true
+          data_net:    {{ provider_data_network }}
+          data_net_name: {{ provider_data_network }}
+{% endif %}
 {% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
@@ -695,6 +727,12 @@ resources:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ stack_name }}
+{% if openshift_use_flannel|default(False)|bool %}
+          attach_data_net: true
+          data_net:    { get_resource: data_net }
+          data_subnet: { get_resource: data_subnet }
+          data_net_name: openshift-ansible-{{ stack_name }}-data-net
+{% endif %}
 {% endif %}
           secgrp:
             - { get_resource: {% if openstack_flat_secgrp|default(False)|bool %}flat-secgrp{% else %}node-secgrp{% endif %} }
@@ -740,7 +778,12 @@ resources:
           key_name:    {{ ssh_public_key }}
 {% if provider_network %}
           net:         {{ provider_network }}
-          net_name:         {{ provider_network }}
+          net_name:    {{ provider_network }}
+{% if openshift_use_flannel|default(False)|bool %}
+          attach_data_net: true
+          data_net:    {{ provider_data_network }}
+          data_net_name: {{ provider_data_network }}
+{% endif %}
 {% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
@@ -749,6 +792,12 @@ resources:
               template: openshift-ansible-cluster_id-net
               params:
                 cluster_id: {{ stack_name }}
+{% if openshift_use_flannel|default(False)|bool %}
+          attach_data_net: true
+          data_net:    { get_resource: data_net }
+          data_subnet: { get_resource: data_subnet }
+          data_net_name: openshift-ansible-{{ stack_name }}-data-net
+{% endif %}
 {% endif %}
           secgrp:
 # TODO(bogdando) filter only required node rules into infra-secgrp

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -647,7 +647,6 @@ resources:
           attach_data_net: true
           data_net:    { get_resource: data_net }
           data_subnet: { get_resource: data_subnet }
-          data_net_name: openshift-ansible-{{ stack_name }}-data-net
 {% endif %}
 {% endif %}
           secgrp:
@@ -721,7 +720,6 @@ resources:
           attach_data_net: true
           data_net:    { get_resource: data_net }
           data_subnet: { get_resource: data_subnet }
-          data_net_name: openshift-ansible-{{ stack_name }}-data-net
 {% endif %}
 {% endif %}
           secgrp:
@@ -781,7 +779,6 @@ resources:
           attach_data_net: true
           data_net:    { get_resource: data_net }
           data_subnet: { get_resource: data_subnet }
-          data_net_name: openshift-ansible-{{ stack_name }}-data-net
 {% endif %}
 {% endif %}
           secgrp:

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -634,12 +634,7 @@ resources:
           key_name:    {{ ssh_public_key }}
 {% if provider_network %}
           net:         {{ provider_network }}
-          net_name:    {{ provider_network }}
-{% if openshift_use_flannel|default(False)|bool %}
-          attach_data_net: true
-          data_net:    {{ provider_data_network }}
-          data_net_name: {{ provider_data_network }}
-{% endif %}
+          net_name:         {{ provider_network }}
 {% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
@@ -713,12 +708,7 @@ resources:
           key_name:    {{ ssh_public_key }}
 {% if provider_network %}
           net:         {{ provider_network }}
-          net_name:    {{ provider_network }}
-{% if openshift_use_flannel|default(False)|bool %}
-          attach_data_net: true
-          data_net:    {{ provider_data_network }}
-          data_net_name: {{ provider_data_network }}
-{% endif %}
+          net_name:         {{ provider_network }}
 {% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }
@@ -778,12 +768,7 @@ resources:
           key_name:    {{ ssh_public_key }}
 {% if provider_network %}
           net:         {{ provider_network }}
-          net_name:    {{ provider_network }}
-{% if openshift_use_flannel|default(False)|bool %}
-          attach_data_net: true
-          data_net:    {{ provider_data_network }}
-          data_net_name: {{ provider_data_network }}
-{% endif %}
+          net_name:         {{ provider_network }}
 {% else %}
           net:         { get_resource: net }
           subnet:      { get_resource: subnet }

--- a/roles/openstack-stack/templates/heat_stack_server.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server.yaml.j2
@@ -68,6 +68,34 @@ parameters:
     description: Subnet resource
 {% endif %}
 
+{% if openshift_use_flannel|default(False)|bool %}
+  attach_data_net:
+    type: boolean
+    default: false
+    label: Attach-data-net
+    description: A switch for data port connection
+
+  data_net:
+    type: string
+    default: ''
+    label: Net ID
+    description: Net resource
+
+  data_net_name:
+    type: string
+    default: ''
+    label: Net name
+    description: Net name
+
+{% if not provider_network %}
+  data_subnet:
+    type: string
+    default: ''
+    label: Subnet ID
+    description: Subnet resource
+{% endif %}
+{% endif %}
+
   secgrp:
     type: comma_delimited_list
     label: Security groups
@@ -128,6 +156,11 @@ outputs:
 {% endif %}
         - addr
 
+{% if openshift_use_flannel|default(False)|bool %}
+conditions:
+  no_data_subnet: {not: { get_param: attach_data_net} }
+{% endif %}
+
 resources:
 
   server:
@@ -138,10 +171,27 @@ resources:
       image:     { get_param: image }
       flavor:    { get_param: flavor }
       networks:
+{% if openshift_use_flannel|default(False)|bool %}
+        if:
+          - no_data_subnet
+{% if use_trunk_ports|default(false)|bool %}
+          - - port:  { get_attr: [trunk-port, port_id] }
+{% else %}
+          - - port:  { get_resource: port }
+{% endif %}
+{% if use_trunk_ports|default(false)|bool %}
+          - - port:  { get_attr: [trunk-port, port_id] }
+{% else %}
+          - - port:  { get_resource: port }
+            - port:  { get_resource: data_port }
+{% endif %}
+
+{% else %}
 {% if use_trunk_ports|default(false)|bool %}
         - port:  { get_attr: [trunk-port, port_id] }
 {% else %}
         - port:  { get_resource: port }
+{% endif %}
 {% endif %}
       user_data:
         get_file: user-data
@@ -172,6 +222,19 @@ resources:
         - subnet: { get_param: subnet }
 {% endif %}
       security_groups: { get_param: secgrp }
+
+{% if openshift_use_flannel|default(False)|bool %}
+  data_port:
+    type: OS::Neutron::Port
+    condition: { not: no_data_subnet }
+    properties:
+      network: { get_param: data_net }
+      port_security_enabled: false
+{% if not provider_network %}
+      fixed_ips:
+        - subnet: { get_param: data_subnet }
+{% endif %}
+{% endif %}
 
 {% if not provider_network %}
   floating-ip:

--- a/roles/openstack-stack/templates/heat_stack_server.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server.yaml.j2
@@ -81,12 +81,6 @@ parameters:
     label: Net ID
     description: Net resource
 
-  data_net_name:
-    type: string
-    default: ''
-    label: Net name
-    description: Net name
-
 {% if not provider_network %}
   data_subnet:
     type: string

--- a/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
@@ -79,12 +79,6 @@ parameters:
     label: Net ID
     description: Net resource
 
-  data_net_name:
-    type: string
-    default: ''
-    label: Net name
-    description: Net name
-
   data_subnet:
     type: string
     default: ''

--- a/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack_server_nofloating.yaml.j2
@@ -66,6 +66,32 @@ parameters:
     label: Subnet ID
     description: Subnet resource
 
+{% if openshift_use_flannel|default(False)|bool %}
+  attach_data_net:
+    type: boolean
+    default: false
+    label: Attach-data-net
+    description: A switch for data port connection
+
+  data_net:
+    type: string
+    default: ''
+    label: Net ID
+    description: Net resource
+
+  data_net_name:
+    type: string
+    default: ''
+    label: Net name
+    description: Net name
+
+  data_subnet:
+    type: string
+    default: ''
+    label: Subnet ID
+    description: Subnet resource
+{% endif %}
+
   secgrp:
     type: comma_delimited_list
     label: Security groups
@@ -105,6 +131,11 @@ outputs:
         - 0
         - addr
 
+{% if openshift_use_flannel|default(False)|bool %}
+conditions:
+  no_data_subnet: {not: { get_param: attach_data_net} }
+{% endif %}
+
 resources:
 
   server_nofloating:
@@ -115,10 +146,27 @@ resources:
       image:     { get_param: image }
       flavor:    { get_param: flavor }
       networks:
+{% if openshift_use_flannel|default(False)|bool %}
+        if:
+          - no_data_subnet
+{% if use_trunk_ports|default(false)|bool %}
+          - - port:  { get_attr: [trunk-port, port_id] }
+{% else %}
+          - - port:  { get_resource: port }
+{% endif %}
+{% if use_trunk_ports|default(false)|bool %}
+          - - port:  { get_attr: [trunk-port, port_id] }
+{% else %}
+          - - port:  { get_resource: port }
+            - port:  { get_resource: data_port }
+{% endif %}
+
+{% else %}
 {% if use_trunk_ports|default(false)|bool %}
         - port:  { get_attr: [trunk-port, port_id] }
 {% else %}
         - port:  { get_resource: port }
+{% endif %}
 {% endif %}
       user_data:
         get_file: user-data
@@ -147,6 +195,19 @@ resources:
       fixed_ips:
         - subnet: { get_param: subnet }
       security_groups: { get_param: secgrp }
+
+{% if openshift_use_flannel|default(False)|bool %}
+  data_port:
+    type: OS::Neutron::Port
+    condition: { not: no_data_subnet }
+    properties:
+      network: { get_param: data_net }
+      port_security_enabled: false
+{% if not provider_network %}
+      fixed_ips:
+        - subnet: { get_param: data_subnet }
+{% endif %}
+{% endif %}
 
 {% if not ephemeral_volumes|default(false)|bool %}
   cinder_volume:


### PR DESCRIPTION
#### What does this PR do?

Document the use case for a separate flannel data network.
Allow Nova servers for openshift cluster to be provisioned
with that isolated data network created and connected to
masters, computes and infra nodes.

#### How should this be manually tested?
Uncomment flannel options in OSEv3 group vars.
Provision an env. Do not deploy the cluster and omit e2e.
Verify if the master, compute, infra node has a second interface eth1 connected to a dedicated isolated Neutron network.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic PTAL
