### PR TITLE
Fixing logic of conditional

### DIFF
--- a/roles/rhsm-subscription/tasks/main.yaml
+++ b/roles/rhsm-subscription/tasks/main.yaml
@@ -48,7 +48,7 @@
         password: "{{ rhsm_password }}"
         state: present
         pool: "{{ rhsm_pool }}"
-      when: "('not registered' in subscribed.stdout or 'Current' not in subscribed.stdout)  and rhsm_user is defined and rhsm_user"
+      when: "('not registered' in subscribed.stdout or 'Current' not in subscribed.stdout) and rhsm_user is defined and rhsm_user"
 
     - name: Check if subscription is attached
       command: subscription-manager list --consumed --pool-only --matches="{{ rhsm_pool }}"

--- a/roles/rhsm-subscription/tasks/main.yaml
+++ b/roles/rhsm-subscription/tasks/main.yaml
@@ -48,7 +48,7 @@
         password: "{{ rhsm_password }}"
         state: present
         pool: "{{ rhsm_pool }}"
-      when: "('not registered' in subscribed.stdout or 'Current' not in subscribed.stdout) and rhsm_user is defined and rhsm_user"
+      when: "('not registered' in subscribed.stdout or 'Current' not in subscribed.stdout)  and rhsm_user is defined and rhsm_user"
 
     - name: Check if subscription is attached
       command: subscription-manager list --consumed --pool-only --matches="{{ rhsm_pool }}"

--- a/roles/rhsm-subscription/tasks/main.yaml
+++ b/roles/rhsm-subscription/tasks/main.yaml
@@ -48,7 +48,7 @@
         password: "{{ rhsm_password }}"
         state: present
         pool: "{{ rhsm_pool }}"
-      when: "'not registered' in subscribed.stdout or 'Current' not in subscribed.stdout and rhsm_user is defined and rhsm_user"
+      when: "('not registered' in subscribed.stdout or 'Current' not in subscribed.stdout) and rhsm_user is defined and rhsm_user"
 
     - name: Check if subscription is attached
       command: subscription-manager list --consumed --pool-only --matches="{{ rhsm_pool }}"


### PR DESCRIPTION
undefined rhsm_user failed on this line because AND precedes OR

#### What does this PR do?
Fixes logic in a registration so it doesn't fire with an undefined rhsm_user (case when using satellite and activation key instead)

#### How should this be manually tested?
Run role with rhsm_user undefined, use satellite with AK instead.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @dav1x @cooktheryan 
