### PR TITLE
Fix error when adding new nodes (number of application nodes > 8)

### DIFF
--- a/reference-architecture/azure-ansible/3.5/add_host.sh
+++ b/reference-architecture/azure-ansible/3.5/add_host.sh
@@ -191,7 +191,7 @@ common_azure()
   if [ $TYPE == 'node' ]
   then
     # Get last 2 numbers and add 1
-    LASTNUMBER=$((${LASTVM: -2}+1))
+    LASTNUMBER=$((10#${LASTVM: -2}+1))
     # Format properly XX
     NEXT=$(printf %02d $LASTNUMBER)
   else

--- a/reference-architecture/azure-ansible/3.6/add_host.sh
+++ b/reference-architecture/azure-ansible/3.6/add_host.sh
@@ -191,7 +191,7 @@ common_azure()
   if [ $TYPE == 'node' ]
   then
     # Get last 2 numbers and add 1
-    LASTNUMBER=$((${LASTVM: -2}+1))
+    LASTNUMBER=$((10#${LASTVM: -2}+1))
     # Format properly XX
     NEXT=$(printf %02d $LASTNUMBER)
   else


### PR DESCRIPTION
#### What does this PR do?
Fix error when adding an application node when number of application nodes is equal or greater than 8.
For instance, when the last application node is named "node08", the script will return an error:
"./add_host.sh: line 194: 09: value too great for base (error token is "09")"

#### How should this be manually tested?
The following lines should be able to be executed to test the bug fix

Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)
`#!/bin/bash

LASTVM="node08"
LASTNUMBER=$((10#${LASTVM: -2}+1))
if [ $LASTNUMBER -eq "09" ]; then
        exit 0
else
        echo "Error"
        exit 1
fi`


#### Is there a relevant Issue open for this?
No open issue.

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
