### PR TITLE
Update the raw github links used by ansible and curl.

### DIFF
--- a/reference-architecture/azure-ansible/3.5/add_host.sh
+++ b/reference-architecture/azure-ansible/3.5/add_host.sh
@@ -215,7 +215,7 @@ add_node_openshift(){
   echo "Adding the new node to the ansible inventory..."
   sudo sed -i "/\[new_nodes\]/a ${VMNAME} openshift_hostname=${VMNAME} openshift_node_labels=\"{'role':'${ROLE}','zone':'default','logging':'true'}\"" /etc/ansible/hosts
   echo "Preparing the host..."
-  ansible new_nodes -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/node.sh | bash -x" >/dev/null
+  ansible new_nodes -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.5/node.sh | bash -x" >/dev/null
   export ANSIBLE_HOST_KEY_CHECKING=False
   ansible-playbook -l new_nodes /home/${USER}/subscribe.yml
   ansible-playbook -l new_nodes -e@vars.yml /home/${USER}/azure-config.yml
@@ -232,7 +232,7 @@ add_master_openshift(){
   sudo sed -i "/\[new_nodes\]/a ${VMNAME} openshift_hostname=${VMNAME} openshift_node_labels=\"{'role':'${ROLE}','zone':'default','logging':'true'}\" openshift_schedulable=false" /etc/ansible/hosts
   sudo sed -i "/\[new_masters\]/a ${VMNAME} openshift_hostname=${VMNAME} openshift_node_labels=\"{'role':'${ROLE}','zone':'default','logging':'true'}\"" /etc/ansible/hosts
   echo "Preparing the host..."
-  ansible new_masters -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/master.sh | bash -x"
+  ansible new_masters -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.5/master.sh | bash -x"
   # Copy ssh files as master.sh does
   ansible master1 -m fetch -a "src=/home/${USER}/.ssh/id_rsa.pub dest=/tmp/key.pub flat=true" >/dev/null
   ansible master1 -m fetch -a "src=/home/${USER}/.ssh/id_rsa dest=/tmp/key flat=true" >/dev/null

--- a/reference-architecture/azure-ansible/3.5/add_host.sh
+++ b/reference-architecture/azure-ansible/3.5/add_host.sh
@@ -191,7 +191,7 @@ common_azure()
   if [ $TYPE == 'node' ]
   then
     # Get last 2 numbers and add 1
-    LASTNUMBER=$((${LASTVM: -2}+1))
+    LASTNUMBER=$((10#${LASTVM: -2}+1))
     # Format properly XX
     NEXT=$(printf %02d $LASTNUMBER)
   else

--- a/reference-architecture/azure-ansible/3.6/add_host.sh
+++ b/reference-architecture/azure-ansible/3.6/add_host.sh
@@ -215,7 +215,7 @@ add_node_openshift(){
   echo "Adding the new node to the ansible inventory..."
   sudo sed -i "/\[new_nodes\]/a ${VMNAME} openshift_hostname=${VMNAME} openshift_node_labels=\"{'role':'${ROLE}','zone':'default','logging':'true'}\"" /etc/ansible/hosts
   echo "Preparing the host..."
-  ansible new_nodes -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/node.sh | bash -x" >/dev/null
+  ansible new_nodes -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.6/node.sh | bash -x" >/dev/null
   export ANSIBLE_HOST_KEY_CHECKING=False
   ansible-playbook -l new_nodes /home/${USER}/subscribe.yml
   ansible-playbook -l new_nodes -e@vars.yml /home/${USER}/azure-config.yml
@@ -232,7 +232,7 @@ add_master_openshift(){
   sudo sed -i "/\[new_nodes\]/a ${VMNAME} openshift_hostname=${VMNAME} openshift_node_labels=\"{'role':'${ROLE}','zone':'default','logging':'true'}\" openshift_schedulable=false" /etc/ansible/hosts
   sudo sed -i "/\[new_masters\]/a ${VMNAME} openshift_hostname=${VMNAME} openshift_node_labels=\"{'role':'${ROLE}','zone':'default','logging':'true'}\"" /etc/ansible/hosts
   echo "Preparing the host..."
-  ansible new_masters -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/master.sh | bash -x"
+  ansible new_masters -m shell -a "curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.6/master.sh | bash -x"
   # Copy ssh files as master.sh does
   ansible master1 -m fetch -a "src=/home/${USER}/.ssh/id_rsa.pub dest=/tmp/key.pub flat=true" >/dev/null
   ansible master1 -m fetch -a "src=/home/${USER}/.ssh/id_rsa dest=/tmp/key flat=true" >/dev/null

--- a/reference-architecture/azure-ansible/3.6/add_host.sh
+++ b/reference-architecture/azure-ansible/3.6/add_host.sh
@@ -191,7 +191,7 @@ common_azure()
   if [ $TYPE == 'node' ]
   then
     # Get last 2 numbers and add 1
-    LASTNUMBER=$((${LASTVM: -2}+1))
+    LASTNUMBER=$((10#${LASTVM: -2}+1))
     # Format properly XX
     NEXT=$(printf %02d $LASTNUMBER)
   else


### PR DESCRIPTION
#### What does this PR do?
Update the raw github links used by ansible and curl in add_host.sh. The former links were dead.

#### How should this be manually tested?
Fetch the new raw github links
`curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.5/node.sh`
`curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.6/node.sh`
`curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.5/master.sh`
`curl -s https://raw.githubusercontent.com/openshift/openshift-ansible-contrib/master/reference-architecture/azure-ansible/3.6/master.sh`

#### Is there a relevant Issue open for this?
No open issue.

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
