### PR TITLE
rollback to remove package to support origin

### DIFF
--- a/roles/prerequisites/defaults/main.yaml
+++ b/roles/prerequisites/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-openshift_required_packages: ['iptables', 'iptables-services', 'atomic-openshift-node', 'NetworkManager', 'docker']
+openshift_required_packages: ['iptables', 'iptables-services', 'NetworkManager', 'docker']


### PR DESCRIPTION
#### What does this PR do?
Rollback to remove atomic-openshift-node package so we can support origin still

#### How should this be manually tested?
manual deployment

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @e-minguez 
