### PR TITLE
Add dynamic inventory

### DIFF
--- a/lookup_plugins/os_cinder.py
+++ b/lookup_plugins/os_cinder.py
@@ -1,0 +1,30 @@
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.plugins.lookup import LookupBase
+
+import shade
+
+
+class LookupModule(LookupBase):
+
+    def run(self, volume_names, variables=None, **kwargs):
+        cloud = shade.openstack_cloud()
+        volume_attributes = [
+            "id",
+            "name",
+            "display_name",
+            "size",
+            "description",
+        ]
+
+        def get_volume(name_or_id):
+            volume = cloud.get_volume(name_or_id)
+            if not volume:
+                raise AnsibleError(
+                    "Could not find volume: {}".format(name_or_id))
+
+            result = {}
+            for attribute_name in volume_attributes:
+                result[attribute_name] = getattr(volume, attribute_name)
+            return result
+
+        return [get_volume(volume_name) for volume_name in volume_names]

--- a/lookup_plugins/os_cinder.py
+++ b/lookup_plugins/os_cinder.py
@@ -1,4 +1,4 @@
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
 import shade

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -361,6 +361,19 @@ registry. Again in `OSEv3.yml`:
 The filesystem value here will be used in the initial formatting of
 the volume.
 
+If you're using the dynamic inventory, you must uncomment these two values as
+well:
+
+    #openshift_hosted_registry_storage_openstack_volumeID: "{{ lookup('os_cinder', cinder_hosted_registry_name).id }}"
+    #openshift_hosted_registry_storage_volume_size: "{{ cinder_hosted_registry_size_gb }}Gi"
+
+But note that they use the `os_cinder` lookup plugin we provide, so you must
+tell Ansible where to find it either in `ansible.cfg` (the one we provide is
+configured properly) or by exporting the
+`ANSIBLE_LOOKUP_PLUGINS=openshift-ansible-contrib/lookup_plugins` environment
+variable.
+
+
 
 ### Use an existing Cinder volume for the OpenShift registry
 

--- a/playbooks/provisioning/openstack/sample-inventory/ansible.cfg
+++ b/playbooks/provisioning/openstack/sample-inventory/ansible.cfg
@@ -1,6 +1,7 @@
 # config file for ansible -- http://ansible.com/
 # ==============================================
 [defaults]
+ansible_user = openshift
 forks = 50
 # work around privilege escalation timeouts in ansible
 timeout = 30
@@ -14,6 +15,8 @@ fact_caching_connection = .ansible/cached_facts
 fact_caching_timeout = 900
 stdout_callback = skippy
 callback_whitelist = profile_tasks
+lookup_plugins = openshift-ansible-contrib/lookup_plugins
+
 
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=900s -o GSSAPIAuthentication=no

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -27,9 +27,14 @@ openshift_hosted_registry_wait: True
 #openshift_hosted_registry_storage_access_modes: ['ReadWriteOnce']
 #openshift_hosted_registry_storage_openstack_filesystem: xfs
 
-## Configure this if you're attaching a Cinder volume you've set up.
+## NOTE(shadower): This won't work until the openshift-ansible issue #5657 is fixed:
+## https://github.com/openshift/openshift-ansible/issues/5657
 ## If you're using the `cinder_hosted_registry_name` option from
-## `all.yml`, this will be configured automaticaly.
+## `all.yml`, uncomment these lines:
+#openshift_hosted_registry_storage_openstack_volumeID: "{{ lookup('os_cinder', cinder_hosted_registry_name).id }}"
+#openshift_hosted_registry_storage_volume_size: "{{ cinder_hosted_registry_size_gb }}Gi"
+
+## If you're using a Cinder volume you've set up yourself, uncomment these lines:
 #openshift_hosted_registry_storage_openstack_volumeID: e0ba2d73-d2f9-4514-a3b2-a0ced507fa05
 #openshift_hosted_registry_storage_volume_size: 10Gi
 

--- a/playbooks/provisioning/openstack/sample-inventory/inventory.py
+++ b/playbooks/provisioning/openstack/sample-inventory/inventory.py
@@ -72,8 +72,9 @@ if __name__ == '__main__':
             'ansible_host': ssh_ip_address
         }
 
-        if server.public_v4:
-            vars['public_v4'] = server.public_v4
+        public_v4 = server.public_v4 or server.private_v4
+        if public_v4:
+            vars['public_v4'] = public_v4
         # TODO(shadower): what about multiple networks?
         if server.private_v4:
             vars['private_v4'] = server.private_v4

--- a/playbooks/provisioning/openstack/sample-inventory/inventory.py
+++ b/playbooks/provisioning/openstack/sample-inventory/inventory.py
@@ -3,8 +3,6 @@
 from __future__ import print_function
 
 import json
-import os
-import sys
 
 import shade
 
@@ -19,7 +17,7 @@ if __name__ == '__main__':
     cluster_hosts = [
         server for server in cloud.list_servers()
         if 'metadata' in server and 'clusterid' in server.metadata]
-    
+
     masters = [server.name for server in cluster_hosts
                if server.metadata['host-type'] == 'master']
 
@@ -30,11 +28,11 @@ if __name__ == '__main__':
 
     infra_hosts = [server.name for server in cluster_hosts
                    if server.metadata['host-type'] == 'node' and
-                        server.metadata['sub-host-type'] == 'infra']
+                   server.metadata['sub-host-type'] == 'infra']
 
     app = [server.name for server in cluster_hosts
            if server.metadata['host-type'] == 'node' and
-               server.metadata['sub-host-type'] == 'app']
+           server.metadata['sub-host-type'] == 'app']
 
     nodes = list(set(masters + infra_hosts + app))
 
@@ -42,22 +40,22 @@ if __name__ == '__main__':
            if server.metadata['host-type'] == 'dns']
 
     lb = [server.name for server in cluster_hosts
-           if server.metadata['host-type'] == 'lb']
+          if server.metadata['host-type'] == 'lb']
 
     osev3 = list(set(nodes + etcd + lb))
 
     groups = [server.metadata.group for server in cluster_hosts
               if 'group' in server.metadata]
 
-    inventory['cluster_hosts'] = { 'hosts': [s.name for s in cluster_hosts] }
-    inventory['OSEv3'] = { 'hosts': osev3 }
-    inventory['masters'] = { 'hosts': masters }
-    inventory['etcd'] = { 'hosts': etcd }
-    inventory['nodes'] = { 'hosts': nodes }
-    inventory['infra_hosts'] = { 'hosts': infra_hosts }
-    inventory['app'] = { 'hosts': app }
-    inventory['dns'] = { 'hosts': dns }
-    inventory['lb'] = { 'hosts': lb }
+    inventory['cluster_hosts'] = {'hosts': [s.name for s in cluster_hosts]}
+    inventory['OSEv3'] = {'hosts': osev3}
+    inventory['masters'] = {'hosts': masters}
+    inventory['etcd'] = {'hosts': etcd}
+    inventory['nodes'] = {'hosts': nodes}
+    inventory['infra_hosts'] = {'hosts': infra_hosts}
+    inventory['app'] = {'hosts': app}
+    inventory['dns'] = {'hosts': dns}
+    inventory['lb'] = {'hosts': lb}
 
     for server in cluster_hosts:
         if 'group' in server.metadata:
@@ -66,7 +64,7 @@ if __name__ == '__main__':
                 inventory[group] = {'hosts': []}
             inventory[group]['hosts'].append(server.name)
 
-    inventory['_meta'] = { 'hostvars': {} }
+    inventory['_meta'] = {'hostvars': {}}
 
     for server in cluster_hosts:
         ssh_ip_address = server.public_v4 or server.private_v4

--- a/playbooks/provisioning/openstack/sample-inventory/inventory.py
+++ b/playbooks/provisioning/openstack/sample-inventory/inventory.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import json
+import os
+import sys
+
+import shade
+
+
+if __name__ == '__main__':
+    cloud = shade.openstack_cloud()
+
+    inventory = {}
+
+    # TODO(shadower): filter the servers based on the `OPENSHIFT_CLUSTER`
+    # environment variable.
+    cluster_hosts = [
+        server for server in cloud.list_servers()
+        if 'metadata' in server and 'clusterid' in server.metadata]
+    
+    masters = [server.name for server in cluster_hosts
+               if server.metadata['host-type'] == 'master']
+
+    etcd = [server.name for server in cluster_hosts
+            if server.metadata['host-type'] == 'etcd']
+    if not etcd:
+        etcd = masters
+
+    infra_hosts = [server.name for server in cluster_hosts
+                   if server.metadata['host-type'] == 'node' and
+                        server.metadata['sub-host-type'] == 'infra']
+
+    app = [server.name for server in cluster_hosts
+           if server.metadata['host-type'] == 'node' and
+               server.metadata['sub-host-type'] == 'app']
+
+    nodes = list(set(masters + infra_hosts + app))
+
+    dns = [server.name for server in cluster_hosts
+           if server.metadata['host-type'] == 'dns']
+
+    lb = [server.name for server in cluster_hosts
+           if server.metadata['host-type'] == 'lb']
+
+    osev3 = list(set(nodes + etcd + lb))
+
+    groups = [server.metadata.group for server in cluster_hosts
+              if 'group' in server.metadata]
+
+    inventory['cluster_hosts'] = { 'hosts': [s.name for s in cluster_hosts] }
+    inventory['OSEv3'] = { 'hosts': osev3 }
+    inventory['masters'] = { 'hosts': masters }
+    inventory['etcd'] = { 'hosts': etcd }
+    inventory['nodes'] = { 'hosts': nodes }
+    inventory['infra_hosts'] = { 'hosts': infra_hosts }
+    inventory['app'] = { 'hosts': app }
+    inventory['dns'] = { 'hosts': dns }
+    inventory['lb'] = { 'hosts': lb }
+
+    for server in cluster_hosts:
+        if 'group' in server.metadata:
+            group = server.metadata.group
+            if group not in inventory:
+                inventory[group] = {'hosts': []}
+            inventory[group]['hosts'].append(server.name)
+
+    inventory['_meta'] = { 'hostvars': {} }
+
+    for server in cluster_hosts:
+        ssh_ip_address = server.public_v4 or server.private_v4
+        vars = {
+            'ansible_host': ssh_ip_address
+        }
+
+        if server.public_v4:
+            vars['public_v4'] = server.public_v4
+        # TODO(shadower): what about multiple networks?
+        if server.private_v4:
+            vars['private_v4'] = server.private_v4
+
+        node_labels = server.metadata.get('node_labels')
+        if node_labels:
+            vars['openshift_node_labels'] = node_labels
+
+        inventory['_meta']['hostvars'][server.name] = vars
+
+    print(json.dumps(inventory, indent=4, sort_keys=True))


### PR DESCRIPTION
#### What does this PR do?

This adds an `inventory.py` script to the `sample-inventory` that lists
all the necessary servers and groups dynamically, skipping the
`static_inventory` role as well as the `hosts` creation.

It also adds an `os_cinder` lookup function which is necessary for a
seamless Cinder OpenShift registry integration without a static
inventory.

#### How should this be manually tested?
1. Update your `ansible.cfg` with the one in this pull request
2. Copy the inventory from this PRs sample-inventory (or just make sure you have the new `inventory.py` file in your inventory)
3. Set `openstack_inventory: dynamic` in `inventory/group_vars/all.yml`
4. Run the openstack provision playbook
5. Verify that the `inventory/hosts` file is **NOT** created.
6. Verify that the provisioning succeeded
7. Run openshift-ansible to install openshift
8. Verify the installation succeeded

Note: this should also work for the "set up and attach cinder registry" scenario, but that's blocked on this openshift-ansible issue:

https://github.com/openshift/openshift-ansible/issues/5657

Also, this might not work for scenarios with provider network, multiple subnets and multiple stacks in the same project. I would prefer to do them in separate pull requests.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @Tlacenka @tzumainn  @bogdando PTAL
