### PR TITLE
Replace the CASL references

### DIFF
--- a/playbooks/provisioning/openstack/pre_tasks.yml
+++ b/playbooks/provisioning/openstack/pre_tasks.yml
@@ -7,7 +7,7 @@
 
 - name: Set default Environment ID
   set_fact:
-    default_env_id: "casl-{{ lookup('env','OS_USERNAME') }}-{{ env_random_id }}"
+    default_env_id: "openshift-{{ lookup('env','OS_USERNAME') }}-{{ env_random_id }}"
   delegate_to: localhost
 
 - name: Setting Common Facts

--- a/roles/openstack-stack/README.md
+++ b/roles/openstack-stack/README.md
@@ -5,5 +5,5 @@ Role for spinning up instances using OpenStack Heat.
 ## To Test
 
 ```
-ansible-playbook casl-ansible/roles/openstack-stack/test/stack-create-test.yml
+ansible-playbook openshift-ansible-contrib/roles/openstack-stack/test/stack-create-test.yml
 ```

--- a/roles/openstack-stack/tasks/generate-templates.yml
+++ b/roles/openstack-stack/tasks/generate-templates.yml
@@ -3,7 +3,7 @@
   register: stack_template_pre
   tempfile:
     state: directory
-    prefix: casl-ansible
+    prefix: openshift-ansible
 
 - name: set template paths
   set_fact:


### PR DESCRIPTION
#### What does this PR do?
Following up on the initial port of the OpenStack roles from
casl-ansible to openshift-ansible-contrib. One of the points that was
brought up in the review was to drop the references to CASL in the
code since the code has now wider reach.


#### How should this be manually tested?
Standart openstack end to end test. Nothing should break.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @tzumainn @Tlacenka  @bogdando 

@oybed @etsauer I'd appreciate you guys taking a look -- do you depend on the values we're changing here?
