### PR TITLE
Adjusting logic on rhsm_user

### DIFF
--- a/roles/rhsm-subscription/tasks/main.yaml
+++ b/roles/rhsm-subscription/tasks/main.yaml
@@ -48,7 +48,7 @@
         password: "{{ rhsm_password }}"
         state: present
         pool: "{{ rhsm_pool }}"
-      when: "'not registered' in subscribed.stdout or 'Current' not in subscribed.stdout and rhsm_user is defined and rhsm_user"
+      when: "('not registered' in subscribed.stdout or 'Current' not in subscribed.stdout) and rhsm_user is defined and rhsm_user"
 
     - name: Check if subscription is attached
       command: subscription-manager list --consumed --pool-only --matches="{{ rhsm_pool }}"


### PR DESCRIPTION
Test for rhsm_user is missed due to and/or precedence.

### What does this PR do?

Adjustment of logic to prevent referencing undefined rhsm_user
### How should this be manually tested?

- Ensure rhsm_user undefined
- Ensure host is not yet registered
- Run role against host.

### Who would you like to review this?

cc: @dav1x @cooktheryan @e-minguez PTAL