### PR TITLE
Switch to the latest openshift-ansible for Openstack CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
 env:
   global:
     - CI_CONCURRENT_JOBS=1
-    - OPENSHIFT_ANSIBLE_COMMIT=openshift-ansible-3.6.22-1
+    - OPENSHIFT_ANSIBLE_COMMIT=master
   matrix:
     - RUN_OPENSTACK_CI=false
     - RUN_OPENSTACK_CI=true


### PR DESCRIPTION
#### What does this PR do?
It switches to using the `master` branch of `openshift-anisble` because it's working again. (side note: we want to get openshift-ansible CI testing our stuff :-( ).

#### How should this be manually tested?
No manual testing necessary, just make sure the end to end CI passes.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tzumainn @Tlacenka  @bogdando PTAL
