### PR TITLE
Add openstack_num_etcd to sample inventory

### DIFF
--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/all.yml
@@ -36,6 +36,7 @@ openstack_default_image_name: "centos7"
 openstack_num_masters: 1
 openstack_num_infra: 1
 openstack_num_nodes: 2
+openstack_num_etcd: 1
 
 # # Used Flavors
 # # - set specific flavors for roles by uncommenting corresponding lines


### PR DESCRIPTION
#### What does this PR do?
Adds openstack_num_etcd to sample inventory, as it seems to be the correct default

#### How should this be manually tested?
Provision using the openstack playbooks; witness the etcd node being created; deploy openshift on top of it with no errors

#### Is there a relevant Issue open for this?
N/A
#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
