### PR TITLE
Add CentOS support to the docker-storage-setup role

### DIFF
--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -25,5 +25,21 @@
     - ansible_distribution_version | version_compare('7.4', '<')
     - ansible_distribution == "RedHat"
 
+- block:
+    - name: create the docker-storage-setup config file for CentOS
+      template:
+        src: "{{ role_path }}/templates/docker-storage-setup-dm.j2"
+        dest: /etc/sysconfig/docker-storage-setup
+        owner: root
+        group: root
+        mode: 0644
+
+  # TODO(shadower): Find out which CentOS version supports overlayfs2
+  when:
+    - ansible_distribution == "CentOS"
+
+- name: Install Docker
+  package: name=docker state=present
+
 - name: start docker
-  service: name=docker state=started enabled=true
+  service: name=docker state=restarted enabled=true


### PR DESCRIPTION
#### What does this PR do?

This let's us use the role on CentOS systems, as well as RHEL. In addition, it
installs docker and makes sure it's restarted (as opposed to just "started"
which has no effect when docker is already running).

These changes will let the OSP provider to use this role instead of our own homemade solution.

#### How should this be manually tested?
Run the docker-storage-setup role on centos and verify that Docker is installed, run and is configured as per the generated docker-storage-setup file.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?

The role seems to be used by the vmware and rhv reference architectures, so in addition to @e-minguez  and @cooktheryan I'd appreciate a look from some of those folks to make sure we're not breaking anything.