### PR TITLE
Create parameter rhsm_hostname

### DIFF
--- a/roles/rhsm-subscription/defaults/main.yaml
+++ b/roles/rhsm-subscription/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+rhsm_server: subscription.rhn.redhat.com
+...

--- a/roles/rhsm-subscription/tasks/main.yaml
+++ b/roles/rhsm-subscription/tasks/main.yaml
@@ -46,6 +46,7 @@
       redhat_subscription:
         username: "{{ rhsm_user }}"
         password: "{{ rhsm_password }}"
+        server_hostname: "{{ rhsm_server }}"
         state: present
         pool: "{{ rhsm_pool }}"
       when: "('not registered' in subscribed.stdout or 'Current' not in subscribed.stdout) and rhsm_user is defined and rhsm_user"


### PR DESCRIPTION
#### What does this PR do?
Creates parameter rhsm_server within rhsm-subscription role affecting server_hostname parameter of redhat_register call.

If using staged rhn services (ethel) for testing, it is useful to be able to register openshift machines to the stage rhn servers instead of the standard. Defaults are designed to be sane, and not affect existing use cases.

#### How should this be manually tested?
1. Run openshift install playbook with no changes--rhsm registration should remain unaffected.

2. Create account on stage RHN server (internal contributors only) and enter the stage server as rhsm_server

#### Is there a relevant Issue open for this?
Enhancement needed while testing Ethel based RHN account in absence of working satellite or RHN account.

#### Who would you like to review this?
cc: @cooktheryan @dav1x @e-minguez 