### PR TITLE
More robust teardown

### DIFF
--- a/reference-architecture/gcp/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
+++ b/reference-architecture/gcp/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
@@ -52,6 +52,7 @@
     - google-compute-engine
     - cloud-init
     - docker
+    - iptables-services
 
   - name: add disk_setup to cloud_config_modules
     lineinfile:
@@ -83,6 +84,9 @@
     gce_pd:
       name: '{{ prefix }}-tmp-instance'
       zone: '{{ gcloud_zone }}'
+      service_account_email: '{{ service_account_id }}'
+      credentials_file: '{{ credentials_file }}'
+      project_id: '{{ gcloud_project }}'
       state: absent
     delegate_to: localhost
 

--- a/reference-architecture/gcp/ansible/playbooks/teardown.yaml
+++ b/reference-architecture/gcp/ansible/playbooks/teardown.yaml
@@ -1,6 +1,14 @@
 ---
+- name: check if ssh proxy is configured
+  hosts: localhost
+  tasks:
+  - name: check if ssh proxy is configured
+    command: grep -q 'OPENSHIFT ON GCP BLOCK' {{ ssh_config_file }}
+    register: ssh_proxy_check
+    ignore_errors: true
+
 - include: unregister.yaml
-  when: hostvars[prefix + '-bastion'] is defined
+  when: ssh_proxy_check | succeeded
 
 - name: teardown the created infrastructure
   hosts: localhost


### PR DESCRIPTION
#### What does this PR do?
If core infrastructure was created, but ssh proxy not configured, teardown
didn't work. This could happen, for example, when there was an issue with core
deployment.

#### How should this be manually tested?
Verify that teardown works in any situation.

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
cc: @cooktheryan PTAL