### PR TITLE
Removed the curly braces in the when statement of docker/tasks/main.yml

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: "Set Docker Storage fact if already configured"
   set_fact:
     docker_storage_setup: true
-  when: pvs.stdout | search('{{ docker_storage_block_device }}.*{{ docker_storage_volume_group }}')
+    when: pvs.stdout | search(docker_storage_block_device ~ '.*' ~ docker_storage_volume_group)
 
 - name: "Configure Docker Storage Setup"
   template:


### PR DESCRIPTION
#### What does this PR do?
I filed issue #805 about the WARNING messages that were coming out of the docker role. The when statement should not have curly braces, so I removed them and tested the result.

#### How should this be manually tested?
I wrote a sample playbook to test my theory of no braces out. It worked and failed when I changed the default storage block device to `/dev/sdb9`.

```yml
---                                    
- name: Test for pvs fix               
  hosts: localhost                     
  vars:                                
    default_docker_storage_block_device: "/dev/sda2"                           
    default_docker_storage_volume_group: "vg_b08-h02-r620"                     

  tasks:                               
    - name: "Setting Docker Facts"     
      set_fact:                        
        docker_storage_block_device: "{{ docker_storage_block_device | default(default_docker_storage_block_device) }}"                                       
        docker_storage_volume_group: "{{ docker_storage_volume_group | default(default_docker_storage_volume_group) }}"                                       

    - debug: msg="Search String '{{ docker_storage_block_device }}.*{{ docker_storage_volume_group }}'"                                                       

    - name: "Check for existing Docker Storage device"                         
      command: pvs                     
      become: true                     
      register: pvs                    
                                       
    - debug: msg="{{ pvs.stdout_lines }}"                                      

    - name: When the search matches, this task get called                      
      debug:                           
        msg: "Found {{ docker_storage_block_device }}.*{{ docker_storage_volume_group }} in the pvs.stdout"                                                   
      when: pvs.stdout | search( docker_storage_block_device ~ '.*' ~ docker_storage_volume_group )
```

#### Is there a relevant Issue open for this?
Yes issue #805 (that I opened).

#### Who would you like to review this?
cc: @tomassedovic @tzumainn  PTAL
