### PR TITLE
Docker storage fix

### DIFF
--- a/reference-architecture/rhv-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/openshift-install.yaml
@@ -11,17 +11,18 @@
     - pre
     - rhsm
 
-- include: ../../../playbooks/openshift-storage.yaml
-  vars:
-    docker_dev: "/dev/vdb"
-    local_volumes_device: "/dev/vdc"
+- hosts: nodes
+  roles:
+    - role: docker-storage-setup
+      docker_dev: '/dev/vdb'
   tags:
     - pre
     - storage
 
-- hosts: masters
+- hosts: schedulable_nodes
   roles:
-    - {"role": docker-storage-setup, "docker_dev": "/dev/vdb"}
+    - role: openshift-volume-quota
+      local_volumes_device: '/dev/vdc'
   tags:
     - pre
     - storage

--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- name: stop docker
+  service: name=docker state=stopped
+
 - block:
     - name: create the docker-storage config file
       template:
@@ -7,7 +10,6 @@
         owner: root
         group: root
         mode: 0644
-
   when:
     - ansible_distribution_version | version_compare('7.4', '>=')
     - ansible_distribution == "RedHat"
@@ -20,7 +22,6 @@
         owner: root
         group: root
         mode: 0644
-
   when:
     - ansible_distribution_version | version_compare('7.4', '<')
     - ansible_distribution == "RedHat"


### PR DESCRIPTION
#### What does this PR do?
- Adds a task to the `docker-storage-setup` role to stop docker before using templates to generate the configuration file. This gets around an issue where the configuration file is not applied if docker is already running (e.g. `prerequisites` playbook is run before `docker-storage-setup` runs.)
- Also re-arranges storage related roles in the RHV `openshift-install` playbook in order to avoid calling `docker-storage-setup` from more than one place.

#### Is there a relevant Issue open for this?
OCP 3.6 on RHV installs are failing with docker-storage health checks.

#### Who would you like to review this?
cc: @cooktheryan @e-minguez @dav1x  PTAL
