### PR TITLE
Hostfile2inventory

### DIFF
--- a/misc/gce-federation/ansible.cfg
+++ b/misc/gce-federation/ansible.cfg
@@ -3,7 +3,7 @@
 [defaults]
 forks = 10
 host_key_checking = False
-hostfile = inventory
+inventory = inventory
 retry_files_enabled = False
 #remote_user = fedora
 private_key_file=/home/rcook/.ssh/google_compute_engine

--- a/reference-architecture/aws-ansible/ansible.cfg
+++ b/reference-architecture/aws-ansible/ansible.cfg
@@ -4,7 +4,7 @@
 #callback_plugins = ../openshift-ansible/ansible-profile/callback_plugins
 forks = 50
 host_key_checking = False
-hostfile = inventory/aws/hosts/ec2.py
+inventory = inventory/aws/hosts/ec2.py
 roles_path = /usr/share/ansible/openshift-ansible/roles:/opt/ansible/roles:./roles:../../roles
 remote_user = ec2-user
 gathering = smart

--- a/reference-architecture/rhv-ansible/ansible.cfg
+++ b/reference-architecture/rhv-ansible/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 forks = 50
 host_key_checking = False
-hostfile = inventory/
+inventory = inventory/
 inventory_ignore_extensions = .example, .ini, .pyc, .pem
 gathering = smart
 # Roles path assumes this repo is checked out to same directory as

--- a/reference-architecture/vmware-ansible/ansible.cfg
+++ b/reference-architecture/vmware-ansible/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 forks = 50
 host_key_checking = False
-hostfile = inventory/vsphere/vms/vmware_inventory.py
+inventory = inventory/vsphere/vms/vmware_inventory.py
 gathering = smart
 roles_path = /usr/share/ansible/openshift-ansible/roles:/opt/ansible/roles:./roles:../../roles
 remote_user = root


### PR DESCRIPTION
#### What does this PR do?
`s/hostfile/inventory/` in `ansible.cfg` where found.
According to [Ansible documentation](http://docs.ansible.com/ansible/2.3/intro_configuration.html#hostfile), the hostfile option has been deprecated since 1.9 and will generate warnings come the 2.5 release.

#### How should this be manually tested?
Use as normal, inventory should work as before. This update touches the following RAs:
- AWS
- GCE
- RHV
- VMWare

#### Is there a relevant Issue open for this?
Found in documentation search

#### Who would you like to review this?
cc: @cooktheryan @e-minguez @dav1x @markllama @rlopez133  PTAL
