### PR TITLE
Fix broken node labels when using with Vagrant 2.0

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -57,6 +57,16 @@ end
 NETWORK_BASE = '192.168.50'
 INTEGRATION_START_SEGMENT = 20
 
+def quote_labels(labels)
+    # Quoting logic for ansible host_vars has changed in Vagrant 2.0
+    # See: https://github.com/hashicorp/vagrant/commit/ac75e409a3470897d56a0841a575e981d60e2e3d
+    if Vagrant::VERSION.to_i >= 2
+      return '{' + labels.map{|k, v| "\"#{k}\": \"#{v}\""}.join(', ') + '}'
+    else
+      return '"{' + labels.map{|k, v| "'#{k}': '#{v}'"}.join(', ') + '}"'
+    end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 #  if Vagrant.has_plugin?("vagrant-cachier")
@@ -175,21 +185,30 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible_host_vars = {
       master1:  {
         openshift_ip: '192.168.50.20',
-        openshift_node_labels: "\"{'region': 'infra', 'zone': 'default'}\"",
+        openshift_node_labels: quote_labels(
+          region: 'infra',
+          zone: 'default',
+        ),
         openshift_schedulable: true,
         ansible_host: '192.168.50.20',
         ansible_ssh_private_key_file: "/home/vagrant/.ssh/master1.key"
       },
       node1: {
         openshift_ip: '192.168.50.21',
-        openshift_node_labels: "\"{'region': 'primary', 'zone': 'east'}\"",
+        openshift_node_labels: quote_labels(
+          region: 'primary',
+          zone: 'east',
+        ),
         openshift_schedulable: true,
         ansible_host: '192.168.50.21',
         ansible_ssh_private_key_file: "/home/vagrant/.ssh/node1.key"
       },
       node2: {
         openshift_ip: '192.168.50.22',
-        openshift_node_labels: "\"{'region': 'primary', 'zone': 'west'}\"",
+        openshift_node_labels: quote_labels(
+          region: 'primary',
+          zone: 'west',
+        ),
         openshift_schedulable: true,
         ansible_host: '192.168.50.22',
         ansible_ssh_private_key_file: "/home/vagrant/.ssh/node2.key"


### PR DESCRIPTION
A broking change has been introduced in Vagrant 2.0 with this commit:
https://github.com/hashicorp/vagrant/commit/ac75e409a3470897d56a0841a575e981d60e2e3d
The change puts additional quotes around the node labels.

As a fix, use different quoting mechanism for Vagrant >=2.0

#### What does this PR do?
Create a function to differentiate between Vagrant versions and
quote host labels accordingly.

#### How should this be manually tested?
I've tested the behaviour with Vagrant 1.9.7 and 2.0.0.
Version 2.0.0 is no longer broken after applying the patch and there's no regression for version 1.9.7.

$ vagrant up

#### Is there a relevant Issue open for this?
https://github.com/openshift/openshift-ansible-contrib/issues/815

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
