### PR TITLE
Set a consistent API/UI endpoint

### DIFF
--- a/ci/openstack/validate.sh
+++ b/ci/openstack/validate.sh
@@ -23,13 +23,13 @@ function restore_dns {
 trap restore_dns EXIT
 
 mkdir -p bin
-scp -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" openshift@master-0.$ENV_ID.example.com:/usr/bin/oc bin/
+scp -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" openshift@console.$ENV_ID.example.com:/usr/bin/oc bin/
 ls -alh bin
 
 export PATH="$PWD/bin:$PATH"
 ENV_ID="openshift-$TRAVIS_BUILD_NUMBER"
 
-oc login --insecure-skip-tls-verify=true https://master-0.$ENV_ID.example.com:8443 -u test -p password
+oc login --insecure-skip-tls-verify=true https://console.$ENV_ID.example.com:8443 -u test -p password
 oc new-project test
 oc new-app --template=cakephp-mysql-example
 

--- a/playbooks/provisioning/openstack/advanced-configuration.md
+++ b/playbooks/provisioning/openstack/advanced-configuration.md
@@ -108,7 +108,7 @@ Either way, find the `oc` binary and put it in your `PATH`.
 
 
 ```
-oc login --insecure-skip-tls-verify=true https://master-0.openshift.example.com:8443 -u user -p password
+oc login --insecure-skip-tls-verify=true https://console.openshift.example.com:8443 -u user -p password
 oc new-project test
 oc new-app --template=cakephp-mysql-example
 oc status -v
@@ -122,7 +122,7 @@ Wait until the build has finished and both pods are deployed and running:
 
 ```
 $ oc status -v
-In project test on server https://master-0.openshift.example.com:8443
+In project test on server https://console.openshift.example.com:8443
 
 http://cakephp-mysql-example-test.apps.openshift.example.com (svc/cakephp-mysql-example)
   dc/cakephp-mysql-example deploys istag/cakephp-mysql-example:latest <-
@@ -153,7 +153,7 @@ Its `title` should say: "Welcome to OpenShift".
 
 You can also access the OpenShift cluster with a web browser by going to:
 
-https://master-0.openshift.example.com:8443
+https://console.openshift.example.com:8443
 
 Note that for this to work, the OpenShift nodes must be accessible
 from your computer and it's DNS configuration must use the cruster's

--- a/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
+++ b/playbooks/provisioning/openstack/sample-inventory/group_vars/OSEv3.yml
@@ -5,8 +5,8 @@ openshift_deployment_type: origin
 openshift_master_default_subdomain: "apps.{{ env_id }}.{{ public_dns_domain }}"
 
 openshift_master_cluster_method: native
-openshift_master_cluster_hostname: "{{ groups.lb.0|default(groups.masters.0) }}"
-openshift_master_cluster_public_hostname: "{{ groups.lb.0|default(groups.masters.0) }}"
+openshift_master_cluster_public_hostname: "console.{{ env_id }}.{{ public_dns_domain }}"
+openshift_master_cluster_hostname: "{{ openshift_master_cluster_public_hostname }}"
 
 osm_default_node_selector: 'region=primary'
 


### PR DESCRIPTION
#### What does this PR do?
Instead of it being the first master hostname in the single-master
scenario or the first load balancer mostname in multi-master, the
sample cluster will always have the following entrypoint by default:

https://console.{{env_id}}.{{public_dns_domain}}:8443

That will simplify the documentation and be easier to look up and
understand for the newcomers trying it out.



#### How should this be manually tested?
The end-to-end CI will exercise this feature on a single master.

There needs to be a manual test on for multiple masters:

1. Copy the sample inventory
2. Set `openstack_num_masters: 3` in `inventory/group_vars/all.yml`
3. Run provisioning
4. Verify that the DNS request for `console.openshift.example.com` returns the floating IP address of the load balancer

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @Tlacenka @tzumainn  @bogdando PTAL
