### PR TITLE
Detect RHEL and Ansible version and using when to call the right module.

### DIFF
--- a/roles/hostnames/tasks/main.yaml
+++ b/roles/hostnames/tasks/main.yaml
@@ -14,6 +14,7 @@
 
 # The hostname module does not work on RHEL version 7.5 with Ansible versions < 2.5
 - name: Checking if this version of RHEL is affected by the hostname problem
+  set_fact:
     rhel75: "{{ (ansible_distribution == 'RedHat') and (ansible_distribution_version | version_compare('7.5', '>=')) }}"
 
 - name: Setting hostname and DNS domain

--- a/roles/hostnames/tasks/main.yaml
+++ b/roles/hostnames/tasks/main.yaml
@@ -7,8 +7,24 @@
   set_fact:
     new_fqdn: "{{ new_hostname }}.{{ full_dns_domain }}"
 
+# Ansible 2.5 fixed the hostname module for RHEL 7.5:  https://github.com/ansible/ansible/pull/31839
+- name: Checking if this version of Ansible has a fix for the hostname module
+  set_fact:
+    hostname_module_fixed: "{{ ansible_version['full'] | version_compare('2.5', '>=') }}"
+
+# The hostname module does not work on RHEL version 7.5 with Ansible versions < 2.5
+- name: Checking if this version of RHEL is affected by the hostname problem
+    rhel75: "{{ (ansible_distribution == 'RedHat') and (ansible_distribution_version | version_compare('7.5', '>=')) }}"
+
 - name: Setting hostname and DNS domain
   hostname: name="{{ new_fqdn }}"
+  # Use the hostname module when not on RHEL 7.5 or on the version of Ansible that fixed the hostname module.
+  when: not rhel75 or hostname_module_fixed
+
+- name: Setting hostname and DNS domain using the command module
+  command: "hostname {{ new_fqdn }}"
+  # Use the command module when RHEL 7.5 or later, and when Ansible does not contain the hostname module fix.
+  when: rhel75 and not hostname_module_fixed
 
 - name: Check for cloud.cfg
   stat: path=/etc/cloud/cloud.cfg


### PR DESCRIPTION
#### What does this PR do?
Uses the command module when the version of RHEL would not work with the hostname module.
Issue #809 

#### How should this be manually tested?
I created a small playbook and tested this on RHEL 7.5 and RHEL 7.4 with Ansible 2.5.0 and Ansible 2.3.2.0. It worked as designed. I was also able to replicate the hostname error on RHEL 7.5 if I changed the versions in the set_facts task.
```yml
---
- name: Playbook to test the detection and avoiding hostname module.
  hosts: localhost
  tasks:
    - name: Checking the versions of Ansible and RHEL               
      set_fact:
        hostname_module_fixed: "{{ ansible_version['full'] | version_compare('2.5', '>=') }}"
        rhel75: "{{ (ansible_distribution == 'RedHat') and (ansible_distribution_version | version_compare('7.5', '>=')) }}"

    - name: Setting hostname using the hostname module
      hostname:
        name: "hostname-safe"
      become: true
      when: not rhel75 or hostname_module_fixed

    - name: Setting hostname using command module
      command: "hostname hostname-unsafe"
      become: true
      when: rhel75 and not hostname_module_fixed
```

#### Is there a relevant Issue open for this?
Issue #809 

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
