### PR TITLE
Fix Flannel SDN setup for openstack provider

### DIFF
--- a/playbooks/provisioning/openstack/net_vars_check.yaml
+++ b/playbooks/provisioning/openstack/net_vars_check.yaml
@@ -5,10 +5,3 @@
   when:
     - openstack_provider_network_name is defined
     - openstack_private_data_network_name is defined
-
-- name: Check the flannel network configuration
-  fail:
-    msg: "A dedicated containers data network is only supported with Flannel SDN"
-  when:
-    - openstack_private_data_network_name is defined
-    - not openshift_use_flannel|default(False)|bool

--- a/playbooks/provisioning/openstack/post-install.yml
+++ b/playbooks/provisioning/openstack/post-install.yml
@@ -10,7 +10,7 @@
 # Enable iptables service on app nodes to persist custom rules (flannel SDN)
 # FIXME(bogdando) w/a https://bugzilla.redhat.com/show_bug.cgi?id=1490820
 - hosts: app
-  gather_facts: False
+  gather_facts: True
   become: True
   vars:
     os_firewall_allow:
@@ -42,14 +42,14 @@
       block:
         - name: set allow/masquerade rules for for flannel/docker
           shell: >-
-            (iptables-save | grep -q custom-flannel-docker-1) ||
+            (iptables-save | grep -q flannel-ocp-allow-docker-traffic) ||
             iptables -A DOCKER -w
             -p all -j ACCEPT
-            -m comment --comment "custom-flannel-docker-1";
-            (iptables-save | grep -q custom-flannel-docker-2) ||
+            -m comment --comment "flannel-ocp-allow-docker-traffic";
+            (iptables-save | grep -q flannel-ocp-masquerade) ||
             iptables -t nat -A POSTROUTING -w
             -o {{flannel_interface|default('eth1')}}
-            -m comment --comment "custom-flannel-docker-2"
+            -m comment --comment "flannel-ocp-masquerade"
             -j MASQUERADE
 
         # NOTE(bogdando) the rules will not be restored, when iptables service unit is disabled & masked


### PR DESCRIPTION
#### What does this PR do?

* Gather facts on app nodes to fix the expiration of cached facts
* Use better names for custom iptables rules for Flannel
* Remove OSEv3 specific pre-flight checks from the common checks

#### How should this be manually tested?
A trivial change, no tests needed.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic @e-minguez  PTAL
