### PR TITLE
Had wrong python sdk listed for RHV 4

### DIFF
--- a/roles/deploy-host/defaults/main.yaml
+++ b/roles/deploy-host/defaults/main.yaml
@@ -10,6 +10,7 @@ openshift_deploy_packages: ['git', 'atomic-openshift-utils']
 # AWS - 'python-click', 'python-netaddr'
 # VMW - 'python-click', 'python-ldap', 'python27'
 # GCP - 'qemu-img', 'python-libcloud', 'python2-jmespath', 'python2-passlib', 'python2-libcloud'
+# RHV = 'python2-jmespath', 'python-ovirt-engine-sdk4'
 
 openshift_deploy_epel_packages: ['python2-boto', 'python-netaddr', 'python2-boto3', 'python-iptools', 'python2-pyvmomi']
 # openshift_deploy_epel_packages_by_provider

--- a/roles/deploy-host/tasks/main.yaml
+++ b/roles/deploy-host/tasks/main.yaml
@@ -50,7 +50,7 @@
 
     - name: "Establish rhv pre-req packages"
       set_fact:
-        openshift_deploy_packages_by_provider: ['ovirt-engine-sdk-python']
+        openshift_deploy_packages_by_provider: ['python-ovirt-engine-sdk4']
 
     - name: "Be sure all pre-req rhv packages are installed"
       yum: name={{item}} state=installed


### PR DESCRIPTION
#### What does this PR do?
Fixes deploy-host install of wrong rpm (error in original doc, not role)

#### How should this be manually tested?
Use deploy-host.yaml playbook to set up workstation host to talk to RHV engine

#### Is there a relevant Issue open for this?
Found in testing/documentation review
