### PR TITLE
Registry selector is role= in instance groups

### DIFF
--- a/reference-architecture/rhv-ansible/ocp-vars.yaml
+++ b/reference-architecture/rhv-ansible/ocp-vars.yaml
@@ -86,7 +86,7 @@ openshift_master_htpasswd_users: {'admin': '$apr1$zAhyA9Ko$rBxBOwAwwtRuuaw8OtCwH
 ### Registry storage
 ## NFS
 openshift_hosted_registry_storage_kind: nfs
-openshift_hosted_registry_selector: region=infra
+openshift_hosted_registry_selector: role=infra
 openshift_hosted_registry_storage_host: 192.168.155.10
 openshift_hosted_registry_storage_nfs_directory: /var/lib/exports
 openshift_hosted_registry_storage_volume_name: registryvol


### PR DESCRIPTION
#### What does this PR do?
Registry is failing to find `region=infra` nodes because we use `role=infra` instead in `instance-groups` role

#### How should this be manually tested?
RHV deploy, check that registry can find a node to run on.

#### Is there a relevant Issue open for this?
Found during documentation.

#### Who would you like to review this?
cc: @dav1x @e-minguez 