### PR TITLE
Add in openshift storage setup to ocp reference arch

### DIFF
--- a/reference-architecture/gcp/ansible/playbooks/openshift-post.yaml
+++ b/reference-architecture/gcp/ansible/playbooks/openshift-post.yaml
@@ -1,5 +1,6 @@
 ---
 - include: ../../../../playbooks/empty-dir-quota.yaml
+- include: ../../../../playbooks/openshift-storage.yaml
 
 - name: post ocp deploy tasks for single master node
   hosts: single_master


### PR DESCRIPTION
When the playbook for GCP installation runs, the node storage setup is not done. This causes the playbook to fail.

The playbook has been tested against the 3.6 commit tag and is able to setup a cluster.

cc: @tomassedovic @bogdando 
