### PR TITLE
Document python-passlib dependency

### DIFF
--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -27,7 +27,8 @@ $ yum -y install python2-boto \
                  python-click \
                  python-httplib2 \
                  python-passlib \
-                 httpd-tools
+                 httpd-tools \
+                 java-1.8.0-openjdk-headless
 ```
 
 ### Deploying OpenShift Origin
@@ -39,7 +40,7 @@ $ yum -y install python-pip git python2-boto \
                  python-netaddr python-httplib2 python-devel \
                  gcc libffi-devel openssl-devel python2-boto3 \
                  python-click python-six python-passlib pyOpenSSL \
-                 httpd-tools
+                 httpd-tools java-1.8.0-openjdk-headless
 $ pip install git+https://github.com/ansible/ansible.git@stable-2.3
 $ mkdir -p /usr/share/ansible/openshift-ansible
 $ git clone https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible

--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -26,7 +26,8 @@ $ yum -y install python2-boto \
                  python2-boto3 \
                  python-click \
                  python-httplib2 \
-                 python-passlib
+                 python-passlib \
+                 httpd-tools
 ```
 
 ### Deploying OpenShift Origin
@@ -37,7 +38,8 @@ $ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rp
 $ yum -y install python-pip git python2-boto \
                  python-netaddr python-httplib2 python-devel \
                  gcc libffi-devel openssl-devel python2-boto3 \
-                 python-click python-six python-passlib pyOpenSSL
+                 python-click python-six python-passlib pyOpenSSL \
+                 httpd-tools
 $ pip install git+https://github.com/ansible/ansible.git@stable-2.3
 $ mkdir -p /usr/share/ansible/openshift-ansible
 $ git clone https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible

--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -25,7 +25,8 @@ $ yum -y install python2-boto \
                  python-six \
                  python2-boto3 \
                  python-click \
-                 python-httplib2
+                 python-httplib2 \
+                 python-passlib
 ```
 
 ### Deploying OpenShift Origin
@@ -36,7 +37,7 @@ $ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rp
 $ yum -y install python-pip git python2-boto \
                  python-netaddr python-httplib2 python-devel \
                  gcc libffi-devel openssl-devel python2-boto3 \
-                 python-click python-six pyOpenSSL
+                 python-click python-six python-passlib pyOpenSSL
 $ pip install git+https://github.com/ansible/ansible.git@stable-2.3
 $ mkdir -p /usr/share/ansible/openshift-ansible
 $ git clone https://github.com/openshift/openshift-ansible.git /usr/share/ansible/openshift-ansible


### PR DESCRIPTION
Metrics deployer in 3.6 requires python-passlib to install.

#### What does this PR do?
Documents the need to install python-passlib on the control machine.

#### How should this be manually tested?
Without this dependency, `ose-on-aws.py` fails with
```
TASK [openshift_metrics : Check that python-passlib is available on the control host] ****************************************************************************************************************
fatal: [ose-master01.interaxo-dev.com]: FAILED! => {
    "assertion": "'not installed' not in passlib_result.stdout",
    "changed": false,
    "evaluated_to": false,
    "failed": true,
    "msg": "python-passlib rpm must be installed on control host"
}
```

#### Who would you like to review this?
cc: @tomassedovic @bogdando PTAL
