### PR TITLE
Docker ss atomicfix

### DIFF
--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -3,7 +3,7 @@
   service: name=docker state=stopped
 
 - block:
-    - name: create the docker-storage config file
+    - name: create the docker-storage-setup overlayfs config file
       template:
         src: "{{ role_path }}/templates/docker-storage-setup-overlayfs.j2"
         dest: /etc/sysconfig/docker-storage-setup
@@ -15,7 +15,7 @@
     - ansible_distribution == "RedHat"
 
 - block:
-    - name: create the docker-storage-setup config file
+    - name: create the docker-storage-setup devicemapper config file
       template:
         src: "{{ role_path }}/templates/docker-storage-setup-dm.j2"
         dest: /etc/sysconfig/docker-storage-setup
@@ -27,7 +27,7 @@
     - ansible_distribution == "RedHat"
 
 - block:
-    - name: create the docker-storage-setup config file for CentOS
+    - name: create the docker-storage-setup devicemapper config file for CentOS
       template:
         src: "{{ role_path }}/templates/docker-storage-setup-dm.j2"
         dest: /etc/sysconfig/docker-storage-setup

--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -52,7 +52,7 @@
   service: name=docker state=restarted enabled=true
 
 - block:
-    - name: (Atomic) Remove extra docker lv
+    - name: (Atomic) Remove extra docker lv from root vg
       lvol:
         lv: docker-pool
         vg: atomicos

--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -50,3 +50,23 @@
 
 - name: start docker
   service: name=docker state=restarted enabled=true
+
+- block:
+    - name: (Atomic) Remove extra docker lv
+      lvol:
+        lv: docker-pool
+        vg: atomicos
+        state: absent
+        force: yes
+    - name: (Atomic) Grow root lv to fill vg
+      lvol:
+        lv: root
+        vg: atomicos
+        size: +100%FREE
+    - name: (Atomic) Grow root fs to match lv
+      filesystem:
+        dev: /dev/mapper/atomicos-root
+        fstype: xfs
+        resizefs: yes
+  when: openshift.common.is_atomic | bool
+...

--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -46,7 +46,7 @@
 
 - name: Install Docker
   package: name=docker state=present
-  when: ansible_pkg_mgr != "unknown"
+  when: not openshift.common.is_atomic | bool
 
 - name: start docker
   service: name=docker state=restarted enabled=true

--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -68,5 +68,8 @@
         dev: /dev/mapper/atomicos-root
         fstype: xfs
         resizefs: yes
+    - name: (Atomic) Force Ansible to re-gather disk facts
+      setup:
+        filter: 'ansible_mounts'
   when: openshift.common.is_atomic | bool
 ...

--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -2,6 +2,11 @@
 - name: stop docker
   service: name=docker state=stopped
 
+- name: remove any existing docker-storage config file
+  file:
+    path: /etc/sysconfig/docker-storage
+    state: absent
+
 - block:
     - name: create the docker-storage-setup overlayfs config file
       template:
@@ -41,6 +46,7 @@
 
 - name: Install Docker
   package: name=docker state=present
+  when: ansible_pkg_mgr != "unknown"
 
 - name: start docker
   service: name=docker state=restarted enabled=true


### PR DESCRIPTION
#### What does this PR do?
- Handle case where docker has already been started and exists (by removing docker-storage sysconfig)
- Handle case where role runs on Atomic Host, (and cannot package install)

#### How should this be manually tested?
Test docker setup on 7.3, 7.4, CentOS, and RHEL Atomic Host

#### Is there a relevant Issue open for this?
Found in testing on Atomic

#### Who would you like to review this?
cc: @dav1x @e-minguez @pschiffe 