### PR TITLE
Explicitly define hostnames for openshift

### DIFF
--- a/reference-architecture/rhv-ansible/playbooks/roles/instance-groups/tasks/main.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/roles/instance-groups/tasks/main.yaml
@@ -2,6 +2,7 @@
 - name: Add masters to requisite groups
   add_host:
     name: "{{ hostvars[item].inventory_hostname }}"
+    openshift_hostname: "{{ hostvars[item].inventory_hostname }}"
     groups: masters, etcd, nodes, cluster_hosts
     openshift_node_labels:
       role: master
@@ -10,6 +11,7 @@
 - name: Add one master to the single_master group
   add_host:
     name: "{{ hostvars[item].inventory_hostname }}"
+    openshift_hostname: "{{ hostvars[item].inventory_hostname }}"
     groups: single_master
     openshift_node_labels:
       role: master
@@ -18,6 +20,7 @@
 - name: Add infrastructure nodes to requisite groups
   add_host:
     name: "{{ hostvars[item].inventory_hostname }}"
+    openshift_hostname: "{{ hostvars[item].inventory_hostname }}"
     groups: nodes, cluster_hosts, schedulable_nodes
     openshift_node_labels:
       role: infra
@@ -26,6 +29,7 @@
 - name: Add app nodes to requisite groups
   add_host:
     name: "{{ hostvars[item].inventory_hostname }}"
+    openshift_hostname: "{{ hostvars[item].inventory_hostname }}"
     groups: nodes, cluster_hosts, schedulable_nodes
     openshift_node_labels:
       role: app
@@ -34,6 +38,7 @@
 - name: Add load balancer node to lb group
   add_host:
     name: "{{ hostvars[item].inventory_hostname }}"
+    openshift_hostname: "{{ hostvars[item].inventory_hostname }}"
     groups: lb, cluster_hosts, nodes
     openshift_node_labels:
       role: lb


### PR DESCRIPTION
#### What does this PR do?
Update instance groups role to explicitly set host names of nodes to prevent sporadic issue where the installer switches between host name and IP.

#### How should this be manually tested?
Install with atomic, determine if all masters create config files with host name instead of IP.

#### Is there a relevant Issue open for this?
Found while testing Atomic.

#### Who would you like to review this?
cc: @dav1x @e-minguez  PTAL
