### PR TITLE
Use FQDN for bastion node

### DIFF
--- a/playbooks/provisioning/openstack/post-provision-openstack.yml
+++ b/playbooks/provisioning/openstack/post-provision-openstack.yml
@@ -7,7 +7,7 @@
     - when: not openstack_use_bastion|default(False)|bool
       wait_for_connection:
     - when: openstack_use_bastion|default(False)|bool
-      delegate_to: bastion
+      delegate_to: "{{ groups['bastions'][0] }}"
       wait_for_connection:
 
 - hosts: cluster_hosts

--- a/roles/static_inventory/tasks/openstack.yml
+++ b/roles/static_inventory/tasks/openstack.yml
@@ -104,9 +104,9 @@
 
     - name: Add bastion node to inventory
       add_host:
-        name: bastion
+        name: '{{ registered_bastion_nodes[0].name }}'
         groups: bastions
-        ansible_host: '{{ registered_bastion_nodes[0].public_v4 }}'
+        ansible_host: '{{ registered_bastion_nodes[0].name }}'
         ansible_fqdn: '{{ registered_bastion_nodes[0].name }}'
         ansible_user: '{{ ssh_user }}'
         ansible_private_key_file: '{{ private_ssh_key }}'

--- a/roles/static_inventory/tasks/sshconfig.yml
+++ b/roles/static_inventory/tasks/sshconfig.yml
@@ -4,7 +4,7 @@
     ssh_proxy_command: >-
       ssh {{ ssh_options }}
       -i {{ private_ssh_key }}
-      {{ ssh_user }}@{{ hostvars['bastion'].ansible_host }}
+      {{ ssh_user }}@{{ hostvars[groups.bastions[0]].public_v4 }}
 
 - name: regenerate ssh config
   template:

--- a/roles/static_inventory/templates/openstack_ssh_config.j2
+++ b/roles/static_inventory/templates/openstack_ssh_config.j2
@@ -1,9 +1,9 @@
 Host *
     IdentitiesOnly yes
 
-Host bastion
-    Hostname {{ hostvars['bastion'].ansible_host }}
-    IdentityFile {{ hostvars['bastion'].ansible_private_key_file }}
+Host {{ groups.bastions[0] }}
+    Hostname {{ hostvars[groups.bastions[0]].public_v4 }}
+    IdentityFile {{ hostvars[groups.bastions[0]].ansible_private_key_file }}
     User {{ ssh_user }}
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null

--- a/roles/static_inventory/templates/ssh-tunnel.service.j2
+++ b/roles/static_inventory/templates/ssh-tunnel.service.j2
@@ -8,7 +8,7 @@ ExecStart=/usr/bin/ssh -NT -o \
    UserKnownHostsFile=/dev/null -o \
    StrictHostKeyChecking=no -o \
    ExitOnForwardFailure=no -i \
-   {{ private_ssh_key }} {{ ssh_user }}@{{ hostvars['bastion'].ansible_host }} \
+   {{ private_ssh_key }} {{ ssh_user }}@{{ hostvars[groups.bastions[0]].public_v4 }} \
    -L 0.0.0.0:{{ ui_port }}:{{ target_ip }}:{{ ui_port }}
 
 


### PR DESCRIPTION
#### What does this PR do?
With ansible 2.4, the short named bastion suddenly stopped
working (can't be connected via SSH by ansible). While it
just works by FQDN names, like we do for other cluster nodes.

Rework the bastion host inventory entry and ssh config entry
to use the direct infra-node-0 FQDN/public IPv4 instead of a 'bastion'
short name alias.

#### How should this be manually tested?
Provision nodes with bastion enabled and static inventory. Nodes should be accessible via the generated ssh config and by ansible -m ping. There should be no the 'bastion' aliased inventory/ssh config host entries anymore.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic @oybed PTAL
