### PR TITLE
Fallback inventory_dir to the env PWD var

### DIFF
--- a/ci/openstack/install-openshift.sh
+++ b/ci/openstack/install-openshift.sh
@@ -17,7 +17,7 @@ export INVENTORY="$PWD/playbooks/provisioning/openstack/sample-inventory"
 
 echo INSTALL OPENSHIFT
 
-ansible-playbook --become --timeout 180 --user openshift -i "$INVENTORY" ../openshift-ansible/playbooks/byo/config.yml -e @extra-vars.yaml
+ansible-playbook --become --timeout 180 --user openshift -i "$INVENTORY" ../openshift-ansible/playbooks/byo/config.yml -e openstack_inventory_path="$INVENTORY" -e @extra-vars.yaml
 
 
 echo Waiting for the router to come up

--- a/ci/openstack/provision.sh
+++ b/ci/openstack/provision.sh
@@ -68,7 +68,7 @@ echo
 echo INSTALL OPENSHIFT
 
 ansible-galaxy install -r playbooks/provisioning/openstack/galaxy-requirements.yaml -p roles
-ansible-playbook --timeout 180 --user openshift -i "$INVENTORY" playbooks/provisioning/openstack/provision.yaml -e @extra-vars.yaml
+ansible-playbook --timeout 180 --user openshift -i "$INVENTORY" playbooks/provisioning/openstack/provision.yaml -e openstack_inventory_path="$INVENTORY" -e @extra-vars.yaml
 
 echo
 echo INVENTORY hosts file:

--- a/playbooks/provisioning/openstack/provision-openstack.yml
+++ b/playbooks/provisioning/openstack/provision-openstack.yml
@@ -14,7 +14,7 @@
         - cinder_hosted_registry_size_gb is defined
     - role: static_inventory
       when: openstack_inventory|default('static') == 'static'
-      inventory_path: "{{ openstack_inventory_path|default(inventory_dir) }}"
+      inventory_path: "{{ openstack_inventory_path|default(lookup('env','PWD') + '/inventory') }}"
       private_ssh_key: "{{ openstack_private_ssh_key|default('') }}"
       ssh_config_path: "{{ openstack_ssh_config_path|default('/tmp/ssh.config.openshift.ansible' + '.' + stack_name) }}"
       ssh_user: "{{ ansible_user }}"


### PR DESCRIPTION
#### What does this PR do?
In ansible 2.4 localhost's inventory_dir is undefined.
Fix this with the env's $PWD lookup used as a fallback.

Fix CI job by passing inventory path as an extra var.

#### How should this be manually tested?
provision and deploy (defaults all) with ansible 2.4.x. e2e shall pass.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic PTAL
