### PR TITLE
Fix the openshift-ansible CI breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
 env:
   global:
     - CI_CONCURRENT_JOBS=1
-    - OPENSHIFT_ANSIBLE_COMMIT=master
+    - OPENSHIFT_ANSIBLE_COMMIT=openshift-ansible-3.7.2-1-8-g56b529e
   matrix:
     - RUN_OPENSTACK_CI=false
     - RUN_OPENSTACK_CI=true

--- a/playbooks/provisioning/openstack/README.md
+++ b/playbooks/provisioning/openstack/README.md
@@ -251,7 +251,6 @@ advanced configuration:
 [bastion]: ./advanced-configuration.md#configure-static-inventory-and-access-via-a-bastion-node
 
 
-
 ## License
 
 Like the rest of the openshift-ansible-contrib repository, the code


### PR DESCRIPTION
#### What does this PR do?

A change in openshift-ansible has broken our OpenStack CI (and deployments):

https://travis-ci.org/openshift/openshift-ansible-contrib/jobs/301329799

This temporarily switches to `openshift-ansible-3.7.2-1-8-g56b529e` which is a commit right before the master breakage was introduced.

#### How should this be manually tested?
No manual testing necessary, just verify that the end to end CI passes.


#### Is there a relevant Issue open for this?
Issue in openshift-ansible: https://github.com/openshift/openshift-ansible/issues/6086

#### Who would you like to review this?
cc: @tzumainn  @bogdando @Tlacenka  PTAL
