### PR TITLE
Fix static inventory

### DIFF
--- a/roles/static_inventory/templates/inventory.j2
+++ b/roles/static_inventory/templates/inventory.j2
@@ -2,10 +2,10 @@
 {% for host in groups['all'] %}
 {% if hostvars[host].get('ansible_connection', '') == 'local' %}
 {{ host }} ansible_connection=local
-{% else %}
+{% elif host and 'ansible_host' in hostvars[host] %}
 
-{{ host }}{% if 'ansible_host' in hostvars[host]
-%} ansible_host={{ hostvars[host]['ansible_host'] }}{% endif %}
+{{ host }} ansible_host={{ hostvars[host]['ansible_host'] }}
+{%- if 'openshift_hostname' in hostvars[host]
 {% if 'private_v4' in hostvars[host]
 %} private_v4={{ hostvars[host]['private_v4'] }}{% endif %}
 {% if 'public_v4' in hostvars[host]

--- a/roles/static_inventory/templates/openstack_ssh_config.j2
+++ b/roles/static_inventory/templates/openstack_ssh_config.j2
@@ -9,7 +9,7 @@ Host bastion
     UserKnownHostsFile=/dev/null
 
 {% for host in groups['all'] | difference(groups['bastions'][0]) %}
-
+{% if host and 'ansible_host' in hostvars[host] %}
 Host {{ host }}
     Hostname {{ hostvars[host].ansible_host }}
     ProxyCommand {{ ssh_proxy_command  }} -W {{ hostvars[host].private_v4 }}:22
@@ -18,4 +18,5 @@ Host {{ host }}
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null
 
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
#### What does this PR do?
Do not add empty hosts into static inventory and ssh config.

#### How should this be manually tested?
Provision openstack VMs with openshift-ansible, then generate a static inventory as a separate playbook called from this repo. There should be no empty/'---' hosts entries in the static `inventory/hosts` file. `ansible -m ping all` should be working with the static SSH config as well.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic PTAL
