### PR TITLE
Enable rngd service in GCP ref. arch.

### DIFF
--- a/reference-architecture/gcp/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
+++ b/reference-architecture/gcp/ansible/playbooks/roles/gold-image-instance/tasks/main.yaml
@@ -53,6 +53,7 @@
     - cloud-init
     - docker
     - iptables-services
+    - rng-tools
 
   - name: add disk_setup to cloud_config_modules
     lineinfile:
@@ -67,6 +68,11 @@
   - name: unregister the system
     include_role:
       name: rhsm-unregister
+
+  - name: enable rngd service
+    service:
+      name: rngd
+      enabled: true
 
   rescue:
   - name: unregister the system


### PR DESCRIPTION
#### What does this PR do?
Enable rngd service in GCP ref. arch. to provide enough entropy.

#### How should this be manually tested?
Verify that instances have enough entropy with:
```
$ cat /proc/sys/kernel/random/entropy_avail
3194
```

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
cc: @e-minguez PTAL