### PR TITLE
Updated dns-records role to allow for greater flexibility

### DIFF
--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -28,10 +28,10 @@
   set_fact:
     private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + (openshift_master_default_subdomain | replace('.' + nsupdate_zone_private, '')), 'ip': hostvars[item]['private_v4'] } ] }}"
   when:
-  - openshift_master_default_subdomain is defined
-  - openshift_master_default_subdomain|trim != ''
+    - openshift_master_default_subdomain is defined
+    - openshift_master_default_subdomain|trim != ''
   with_items:
-  - "{{ groups['infra_hosts'] }}"
+    - "{{ groups['infra_hosts'] }}"
 
 - name: "Add public master cluster hostname records to the private A records (single master)"
   set_fact:
@@ -81,19 +81,19 @@
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[item]['ansible_fqdn'] | replace('.' + nsupdate_zone_public, '')), 'ip': hostvars[item]['public_v4'] } ] }}"
   with_items:
-  - "{{ groups['cluster_hosts'] }}"
+    - "{{ groups['cluster_hosts'] }}"
   when:
-  - hostvars[item]['public_v4'] is defined
+    - hostvars[item]['public_v4'] is defined
 
 - name: "Add wildcard records to the public A records"
   set_fact:
     public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + (openshift_master_default_subdomain | replace('.' + nsupdate_zone_public, '')), 'ip': hostvars[item]['public_v4'] } ] }}"
   with_items:
-  - "{{ groups['infra_hosts'] }}"
+    - "{{ groups['infra_hosts'] }}"
   when:
-  - openshift_master_default_subdomain is defined
-  - openshift_master_default_subdomain|trim != ''
-  - hostvars[item]['public_v4'] is defined
+    - openshift_master_default_subdomain is defined
+    - openshift_master_default_subdomain|trim != ''
+    - hostvars[item]['public_v4'] is defined
 
 - name: "Add public master cluster hostname records to the public A records (single master)"
   set_fact:

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -1,27 +1,4 @@
 ---
-- name: "Generate list of private A records"
-  set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[item]['ansible_hostname'], 'ip': hostvars[item]['private_v4'] } ] }}"
-  with_items: "{{ groups['cluster_hosts'] }}"
-
-- name: "Add wildcard records to the private A records for infrahosts"
-  set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_app_domain, 'ip': hostvars[item]['private_v4'] } ] }}"
-  with_items: "{{ groups['infra_hosts'] }}"
-
-- name: "Add public master cluster hostname records to the private A records (single master)"
-  set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].private_v4 } ] }}"
-  when:
-    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - openstack_num_masters == 1
-
-- name: "Add public master cluster hostname records to the private A records (multi-master)"
-  set_fact:
-    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].private_v4 } ] }}"
-  when:
-    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - openstack_num_masters > 1
 
 - name: "Set the private DNS server to use the external value (if provided)"
   set_fact:
@@ -29,6 +6,7 @@
     nsupdate_key_secret_private: "{{ external_nsupdate_keys['private']['key_secret'] }}"
     nsupdate_key_algorithm_private: "{{ external_nsupdate_keys['private']['key_algorithm'] }}"
     nsupdate_private_key_name: "{{ external_nsupdate_keys['private']['key_name']|default('private-' + full_dns_domain) }}"
+    nsupdate_zone_private: "{{ external_nsupdate_keys['private']['zone']|default(full_dns_domain) }}"
   when:
     - external_nsupdate_keys is defined
     - external_nsupdate_keys['private'] is defined
@@ -41,51 +19,44 @@
   when:
     - nsupdate_server_private is undefined
 
+- name: "Generate list of private A records"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[item]['ansible_fqdn'] | replace('.' + nsupdate_zone_private, '')), 'ip': hostvars[item]['private_v4'] } ] }}"
+  with_items: "{{ groups['cluster_hosts'] }}"
+
+- name: "Add wildcard records to the private A records for infrahosts"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + (openshift_master_default_subdomain | replace('.' + nsupdate_zone_private, '')), 'ip': hostvars[item]['private_v4'] } ] }}"
+  when:
+  - openshift_master_default_subdomain is defined
+  - openshift_master_default_subdomain|trim != ''
+  with_items:
+  - "{{ groups['infra_hosts'] }}"
+
+- name: "Add public master cluster hostname records to the private A records (single master)"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone_private, ''))[:-1], 'ip': hostvars[groups.masters[0]].private_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters == 1
+
+- name: "Add public master cluster hostname records to the private A records (multi-master)"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone_private, ''))[:-1], 'ip': hostvars[groups.lb[0]].private_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters > 1
+
 - name: "Generate the private Add section for DNS"
   set_fact:
     private_named_records:
       - view: "private"
-        zone: "{{ full_dns_domain }}"
+        zone: "{{ nsupdate_zone_private }}"
         server: "{{ nsupdate_server_private }}"
         key_name: "{{ nsupdate_private_key_name|default('private-' + full_dns_domain) }}"
         key_secret: "{{ nsupdate_key_secret_private }}"
         key_algorithm: "{{ nsupdate_key_algorithm_private | lower }}"
         entries: "{{ private_records }}"
-
-- name: "Generate list of public A records"
-  set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': hostvars[item]['ansible_hostname'], 'ip': hostvars[item]['public_v4'] } ] }}"
-  with_items: "{{ groups['cluster_hosts'] }}"
-  when: hostvars[item]['public_v4'] is defined
-
-- name: "Add wildcard records to the public A records"
-  set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + openshift_app_domain, 'ip': hostvars[item]['public_v4'] } ] }}"
-  with_items: "{{ groups['infra_hosts'] }}"
-  when: hostvars[item]['public_v4'] is defined
-
-- name: "Add public master cluster hostname records to the public A records (single master)"
-  set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
-  when:
-    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - openstack_num_masters == 1
-    - not use_bastion|bool
-
-- name: "Add public master cluster hostname records to the public A records (single master behind a bastion)"
-  set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.bastions[0]].public_v4 } ] }}"
-  when:
-    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - openstack_num_masters == 1
-    - use_bastion|bool
-
-- name: "Add public master cluster hostname records to the public A records (multi-master)"
-  set_fact:
-    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(full_dns_domain, ''))[:-1], 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
-  when:
-    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
-    - openstack_num_masters > 1
 
 - name: "Set the public DNS server details to use the external value (if provided)"
   set_fact:
@@ -93,6 +64,7 @@
     nsupdate_key_secret_public: "{{ external_nsupdate_keys['public']['key_secret'] }}"
     nsupdate_key_algorithm_public: "{{ external_nsupdate_keys['public']['key_algorithm'] }}"
     nsupdate_public_key_name: "{{ external_nsupdate_keys['public']['key_name']|default('public-' + full_dns_domain) }}"
+    nsupdate_zone_public: "{{ external_nsupdate_keys['public']['zone']|default(full_dns_domain) }}"
   when:
     - external_nsupdate_keys is defined
     - external_nsupdate_keys['public'] is defined
@@ -105,11 +77,52 @@
   when:
     - nsupdate_server_public is undefined
 
+- name: "Generate list of public A records"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[item]['ansible_fqdn'] | replace('.' + nsupdate_zone_public, '')), 'ip': hostvars[item]['public_v4'] } ] }}"
+  with_items:
+  - "{{ groups['cluster_hosts'] }}"
+  when:
+  - hostvars[item]['public_v4'] is defined
+
+- name: "Add wildcard records to the public A records"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + (openshift_master_default_subdomain | replace('.' + nsupdate_zone_public, '')), 'ip': hostvars[item]['public_v4'] } ] }}"
+  with_items:
+  - "{{ groups['infra_hosts'] }}"
+  when:
+  - openshift_master_default_subdomain is defined
+  - openshift_master_default_subdomain|trim != ''
+  - hostvars[item]['public_v4'] is defined
+
+- name: "Add public master cluster hostname records to the public A records (single master)"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone_public, ''))[:-1], 'ip': hostvars[groups.masters[0]].public_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters == 1
+    - not use_bastion|bool
+
+- name: "Add public master cluster hostname records to the public A records (single master behind a bastion)"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone_public, ''))[:-1], 'ip': hostvars[groups.bastions[0]].public_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters == 1
+    - use_bastion|bool
+
+- name: "Add public master cluster hostname records to the public A records (multi-master)"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone_public, ''))[:-1], 'ip': hostvars[groups.lb[0]].public_v4 } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters > 1
+
 - name: "Generate the public Add section for DNS"
   set_fact:
     public_named_records:
       - view: "public"
-        zone: "{{ full_dns_domain }}"
+        zone: "{{ nsupdate_zone_public }}"
         server: "{{ nsupdate_server_public }}"
         key_name: "{{ nsupdate_public_key_name|default('public-' + full_dns_domain) }}"
         key_secret: "{{ nsupdate_key_secret_public }}"

--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -16,6 +16,7 @@
     nsupdate_server_private: "{{ hostvars[groups['dns'][0]].public_v4 }}"
     nsupdate_key_secret_private: "{{ hostvars[groups['dns'][0]].nsupdate_keys['private-' + full_dns_domain].key_secret }}"
     nsupdate_key_algorithm_private: "{{ hostvars[groups['dns'][0]].nsupdate_keys['private-' + full_dns_domain].key_algorithm }}"
+    nsupdate_zone_private: "{{ full_dns_domain }}"
   when:
     - nsupdate_server_private is undefined
 
@@ -74,6 +75,7 @@
     nsupdate_server_public: "{{ hostvars[groups['dns'][0]].public_v4 }}"
     nsupdate_key_secret_public: "{{ hostvars[groups['dns'][0]].nsupdate_keys['public-' + full_dns_domain].key_secret }}"
     nsupdate_key_algorithm_public: "{{ hostvars[groups['dns'][0]].nsupdate_keys['public-' + full_dns_domain].key_algorithm }}"
+    nsupdate_zone_public: "{{ full_dns_domain }}"
   when:
     - nsupdate_server_public is undefined
 


### PR DESCRIPTION
#### What does this PR do?
In preparation for discontinuing the management of the DNS server as part of these tools, this PR updates the `dns-records` role to better align with dns server zones to allow for better flexibility when utilizing external DNS server(s). This is done by using the `fqdn` and stripping the matching `zone` (which may be the `full_dns_domain` if not provided as part of the inventory). This allows the records to use a sub-domain of the zone.

#### How should this be manually tested?
Provision an OpenShift cluster and observe no errors for DNS records adding tasks. To test "new functionality", use external DNS servers, declare the `external_nsupdate_keys` in the inventory and make sure to set the `zone` as part of the public and private section, e.g.: 

```
external_nsupdate_keys:
  public:
    key_secret: '<value-here>'
    key_algorithm: '<value-here>'
    server: '<value-here>'
    key_name: '<value-here>'
    zone: '<value-here>'
  private:
    key_secret: '<value-here>'
    key_algorithm: '<value-here>'
    server: '<value-here>'
    key_name: '<value-here>'
    zone: '<value-here>'
```

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic @bogdando @etsauer 
