### PR TITLE
Fixing compatible issues between repos

### DIFF
--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -562,14 +562,14 @@ resources:
       - interface
 {% endif %}
 
-{% if master_server_group_policies|length > 0 %}
+{% if master_server_group_policies is defined and master_server_group_policies|length > 0 %}
   master_server_group:
     type: OS::Nova::ServerGroup
     properties:
       name: master_server_group
       policies: {{ master_server_group_policies }}
 {% endif %}
-{% if infra_server_group_policies|length > 0 %}
+{% if infra_server_group_policies is defined and infra_server_group_policies|length > 0 %}
   infra_server_group:
     type: OS::Nova::ServerGroup
     properties:
@@ -689,7 +689,7 @@ resources:
           attach_float_net: false
 {% endif %}
           volume_size: {{ master_volume_size }}
-{% if master_server_group_policies|length > 0 %}
+{% if master_server_group_policies is defined and master_server_group_policies|length > 0 %}
           scheduler_hints:
             group: { get_resource: master_server_group }
 {% endif %}
@@ -827,7 +827,7 @@ resources:
           floating_network: {{ external_network }}
 {% endif %}
           volume_size: {{ infra_volume_size }}
-{% if infra_server_group_policies|length > 0 %}
+{% if infra_server_group_policies is defined and infra_server_group_policies|length > 0 %}
           scheduler_hints:
             group: { get_resource: infra_server_group }
 {% endif %}


### PR DESCRIPTION
#### What does this PR do?
Fixing issues due to PR https://github.com/openshift/openshift-ansible-contrib/pull/747 . The introductions of the `*_server_group_policies` causes issues with existing inventories within the CASL repo + should be an optional configuration parameter. 

#### How should this be manually tested?
Run with one of the CASL repo inventories

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic @tzumainn @bogdando @etsauer 
