### PR TITLE
Adding 'ignore_errors' to tasks that may fail

### DIFF
--- a/roles/openshift-pv-cleanup/tasks/main.yml
+++ b/roles/openshift-pv-cleanup/tasks/main.yml
@@ -3,13 +3,20 @@
 - name: Get all projects
   command: >
     oc get projects -o jsonpath='{ .items[*].metadata.name }'
+  ignore_errors: True
   register: projects
 
 - name: Delete all persistent volume claims in cluster
   command: >
     oc delete pvc --all -n {{ item }}
-  with_items: "{{ projects.stdout.split(' ') }}"
+  ignore_errors: True
+  when:
+    - projects is defined
+    - projects.stdout is defined
+  with_items:
+    - "{{ projects.stdout.split(' ') }}"
 
 - name: Delete all persistent volumes in cluster
   command: >
     oc delete pvc --all
+  ignore_errors: True


### PR DESCRIPTION
#### What does this PR do?
The PV clean-up task may fail in the cases where an OpenShift cluster isn't operational or for some other reason don't respond to the commands. This will fail other tasks depending on this role, e.g.: deleting a cluster that's not operational. By adding `ignore_errors` the role will allow us to proceed, even though it may not have been successful from its viewpoint. 

#### How should this be manually tested?
Use the delete cluster playbook(s) in CASL, etc. and attempt to delete a cluster that's not operational. 

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic 
