### PR TITLE
[VMWare] Make 'infrastructure.json' file be pretty

### DIFF
--- a/reference-architecture/vmware-ansible/ocp-on-vmware.py
+++ b/reference-architecture/vmware-ansible/ocp-on-vmware.py
@@ -459,7 +459,7 @@ class VMwareOnOCP(object):
         print "# Please note, if you have chosen to bring your own loadbalancer and NFS Server you will need to ensure that these records are added to DNS and properly resolve. "
 
         with open(self.inventory_file, 'w') as outfile:
-            json.dump(d, outfile)
+            json.dump(d, outfile, indent=4, sort_keys=True)
 
         if self.args.create_inventory:
             exit(0)


### PR DESCRIPTION
Currently, 'ocp-on-vmware' module builds 'infrastructure.json' file
without any indentation. And in this case it is not really readable.
So, update this module to use indentation and sorting by dict keys
to have more constant and understandable structure of the
'infrastructure.json' file.

To see the changes do the following:
1) Configure "./reference-architecture/vmware-ansible/ocp-on-vmware.ini"
2) Run `$ ./reference-architecture/vmware-ansible/ocp-on-vmware.py --create_inventory`

#### Who would you like to review this?

cc: @dav1x @cooktheryan 