### PR TITLE
Fix #891: add a generic etcd-storage role

### DIFF
--- a/roles/etcd-storage/README.md
+++ b/roles/etcd-storage/README.md
@@ -1,0 +1,39 @@
+Role Name
+=========
+
+This role stores /var/lib/etcd data on given device (eg. /dev/sdd) creating a specific vg and lv. 
+
+Requirements
+------------
+
+none
+
+Role Variables
+--------------
+
+Variable naming mimic the docker-storage ones.
+
+`etcd_vol`: the device to use for creating the vg_etcd. Defaults to /dev/sdd.
+
+
+Dependencies
+------------
+
+none
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+        - hosts: localhost
+          remote_user: root
+          roles:
+            - role: etcd-storage
+              etcd_dev: /dev/sdd
+
+License
+-------
+
+BSD
+

--- a/roles/etcd-storage/defaults/main.yml
+++ b/roles/etcd-storage/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for etcd-storage
+etcd_dev: /dev/sde

--- a/roles/etcd-storage/tasks/etcd_volume.yml
+++ b/roles/etcd-storage/tasks/etcd_volume.yml
@@ -1,0 +1,55 @@
+---
+
+- name: Stop etcd
+  service:
+    name: etcd
+    state: stopped
+
+- name: Fail if etcd is started. Cannot hot-change datadir.
+  check_mode: no
+  changed_when: false
+  failed_when: etcd_status.rc == 0
+  register: etcd_status
+  shell: |
+    systemctl status etcd.service
+
+- name: Create vg for etcd
+  lvg:
+    vg: etcd_vg
+    pvs: "{{etcd_dev}}"
+
+- name: create lv for etcd
+  lvol:
+    vg: etcd_vg
+    lv: etcd_lv
+    size: 95%FREE
+    shrink: no
+
+- name: create fs for etcd
+  filesystem:
+    fstype: xfs
+    dev: /dev/etcd_vg/etcd_lv
+
+- name: Stop etcd before remount
+  service:
+    name: etcd
+    state: stopped
+
+- name: ensure mountpoint has the right permissions
+  file:
+    dest: /var/lib/etcd
+    owner: etcd
+    group: etcd
+    state: directory
+
+- name: create fstab entry
+  mount:
+    path: /var/lib/etcd
+    fstype: xfs
+    src: /dev/etcd_vg/etcd_lv
+    state: mounted
+    opts: defaults
+
+- name: Recover /var/lib/etcd context
+  shell: |
+    restorecon -Rv /var/lib/etcd

--- a/roles/etcd-storage/tasks/main.yml
+++ b/roles/etcd-storage/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Check if /var/lib/etcd is already mounted.
+  check_mode: no
+  failed_when: false
+  register: etcd_volume_ok
+  command: |
+    grep  /var/lib/etcd /proc/mounts
+
+- name: Skip role if /var/lib/etcd is mounted.
+  when: etcd_volume_ok.rc != 0
+  import_tasks: etcd_volume.yml

--- a/roles/etcd-storage/tests/inventory
+++ b/roles/etcd-storage/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/etcd-storage/tests/test.yml
+++ b/roles/etcd-storage/tests/test.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - role: etcd-storage
+      etcd_dev: /dev/sdd


### PR DESCRIPTION
#### What does this PR do?
Add a generic etcd-storage role

#### How should this be manually tested?
Run this playbook to prepare nodes *before* installing OCP.
```
        - hosts: etcd
          roles:
            - role: etcd-storage
              etcd_dev: /dev/sdd

```

#### Is there a relevant Issue open for this?
See  https://github.com/openshift/openshift-ansible-contrib/pull/722

#### Who would you like to review this?
cc: @tomassedovic PTAL  @rlopez133 @cooktheryan @e-minguez