### PR TITLE
Fixes #893. Check if the target fs exists.

### DIFF
--- a/roles/openshift-volume-quota/tasks/main.yaml
+++ b/roles/openshift-volume-quota/tasks/main.yaml
@@ -1,5 +1,10 @@
 ---
-- name: Create filesystem for /var/lib/origin/openshift.local.volumes
+- name: Create filesystem for /var/lib/origin/openshift.local.volumes only if it's not present.
+  when:
+  - >-
+    ansible_mounts | json_query("[?device=='" + local_volumes_device + "']") | length == 0
+  - >-
+    ansible_mounts | json_query("[?mount=='" + local_volumes_path + "']") | length == 0
   filesystem:
     fstype: "{{ local_volumes_fstype }}"
     dev: "{{ local_volumes_device }}"


### PR DESCRIPTION

  Running this role on a node which already has a device mounted on the
    target mountpoint results in an error. This check makes the role
    to understand that everything is fine.

#### What does this PR do?
Check if the target filesystem on the given device / mountpoint is present

#### How should this be manually tested?

Create the following playbook and run it twice. 

```
cat > /tmp/test.yml <<EOF
---
- hosts: nodes
  roles:
  - openshift-volume-quota
EOF

ansible-playbook /tmp/test.yml

ansible-playbook /tmp/test.yml
```

#### Is there a relevant Issue open for this?
#893 

#### Who would you like to review this?
cc: @tomassedovic PTAL
