### PR TITLE
[VMWare] Fix oauth config for OCP installation

### DIFF
--- a/reference-architecture/vmware-ansible/ocp-on-vmware.py
+++ b/reference-architecture/vmware-ansible/ocp-on-vmware.py
@@ -481,7 +481,16 @@ class VMwareOnOCP(object):
         if not self.no_confirm:
             click.confirm('Continue using these values?', abort=True)
 
-        if self.auth_type == 'ldap':
+        if self.auth_type == 'none':
+            playbooks = ["playbooks/ocp-install.yaml", "playbooks/minor-update.yaml"]
+            for ocp_file in playbooks:
+                for line in fileinput.input(ocp_file, inplace=True):
+                    if line.startswith('#openshift_master_identity_providers:'):
+                        line = line.replace('#', '    ')
+                        print line
+                    else:
+                        print line,
+        elif self.auth_type == 'ldap':
             l_bdn = ""
 
             for d in self.ldap_fqdn.split("."):
@@ -550,15 +559,11 @@ class VMwareOnOCP(object):
                 else:
                     print line,
 
-            if self.auth_type == 'none':
-                playbooks = ["playbooks/ocp-install.yaml", "playbooks/minor-update.yaml"]
-                for ocp_file in playbooks:
-                    for line in fileinput.input(ocp_file, inplace=True):
-                        if line.startswith('#openshift_master_identity_providers:'):
-                            line = line.replace('#', '    ')
-                            print line
-                        else:
-                            print line,
+        else:
+            print ("'auth_type' configuration has improper value '%s'. "
+                   "It is allowed to be either "
+                   "'ldap' or 'none'." % self.auth_type)
+            exit(1)
         if self.args.create_ocp_vars:
             exit(0)
 


### PR DESCRIPTION
#### What does this PR do?
This PR makes VMWare cloud provider "auth_type=none" config option work. It is treated as supported approach, but broken de-facto.

#### How should this be manually tested?
Common run of OCP installation on top of VMWare would be enough.

#### Is there a relevant Issue open for this?
#895 
#### Who would you like to review this?
cc: @tomassedovic @dav1x @cooktheryan PTAL
