### PR TITLE
Locking the dependency on infra-ansible to v1.0.0

### DIFF
--- a/playbooks/provisioning/openstack/galaxy-requirements.yaml
+++ b/playbooks/provisioning/openstack/galaxy-requirements.yaml
@@ -3,7 +3,7 @@
 
 # From 'infra-ansible'
 - src: https://github.com/redhat-cop/infra-ansible
-  version: master
+  version: v1.0.0
 
 # From 'openshift-ansible'
 - src: https://github.com/openshift/openshift-ansible


### PR DESCRIPTION
#### What does this PR do?
Locking the infra-ansible dependency on `v1.0.0` as there seems to be users still utilizing this and the master branch of infra-ansible moved forward with some additional changes. 

More details here:
https://github.com/redhat-cop/infra-ansible/pull/114#issuecomment-354858297

#### How should this be manually tested?
Provision utilizing the normal procedure, including using `ansible-galaxy`

#### Is there a relevant Issue open for this?
resolves #899 

#### Who would you like to review this?
cc: @tomassedovic @bogdando 

  