### PR TITLE
remove privilege escalation from inventory file creation

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/aws-ansible/playbooks/openshift-install.yaml
@@ -35,6 +35,7 @@
 - hosts: localhost
   connection: local
   gather_facts: no
+  become: no
   roles:
   - cfn-outputs
   - inventory-file-creation


### PR DESCRIPTION
#### What does this PR do?
Removes unnecessary privilege escalation for inventory file creation for AWS installation, which causes the playbook to fail if you don't have passwordless sudo on the installation host.

#### Who would you like to review this?
cc: @tomassedovic PTAL

  