### PR TITLE
oVirt roles move

### DIFF
--- a/reference-architecture/rhv-ansible/README.md
+++ b/reference-architecture/rhv-ansible/README.md
@@ -28,8 +28,10 @@ $ cd ~/git/openshift-ansible-contrib && ansible-playbook playbooks/deploy-host.y
 ```
 
 ### oVirt Ansible roles
-A copy of the [oVirt Ansible](https://github.com/ovirt/ovirt-ansible) repository will be cloned in a directory
-alongside this repository. Roles from within the ovirt-ansible repository will be called by playbooks in this one.
+[oVirt Ansible roles](https://github.com/ovirt/ovirt-ansible) will be installed from
+[Ansible Galaxy](https://galaxy.ansible.com/)
+into your system's Ansible role path, typically `/etc/ansible/roles`. These are required for playbooks to interact
+with RHV to create VMs.
 
 ### Dynamic Inventory
 A copy of `ovirt4.py` from the Ansible project is provided under the inventory directory. This script will, given credentials to a RHV 4 engine, populate the Ansible inventory with facts about all virtual machines in the cluster. In order to use this dynamic inventory, see the `ovirt.ini.example` file, either providing the relevant Python secrets via environment variables, or by copying it to `ovirt.ini` and filling in the values.
@@ -44,7 +46,7 @@ $ curl --output ca.pem 'http://engine.example.com/ovirt-engine/services/pki-reso
 ```
 
 ### RHEL QCOW2 Image
-The ovirt-ansible role, oVirt.image-template requires a URL to download a QCOW2 KVM image to use as
+The oVirt-ansible role, oVirt.image-template requires a URL to download a QCOW2 KVM image to use as
 the basis for the VMs on which OpenShift will be installed. If a CentOS image is desired, a suitable
 URL is commented out in the variable file, `playbooks/vars/ovirt-infra-vars.yaml`. If a RHEL image
 is preferred, log in at <https://access.redhat.com/>, navigate to Downloads, Red Hat Enterprise Linux,

--- a/reference-architecture/rhv-ansible/README.md
+++ b/reference-architecture/rhv-ansible/README.md
@@ -44,7 +44,7 @@ $ curl --output ca.pem 'http://engine.example.com/ovirt-engine/services/pki-reso
 ```
 
 ### RHEL QCOW2 Image
-The ovirt-ansible role, ovirt-image-template requires a URL to download a QCOW2 KVM image to use as
+The ovirt-ansible role, oVirt.image-template requires a URL to download a QCOW2 KVM image to use as
 the basis for the VMs on which OpenShift will be installed. If a CentOS image is desired, a suitable
 URL is commented out in the variable file, `playbooks/vars/ovirt-infra-vars.yaml`. If a RHEL image
 is preferred, log in at <https://access.redhat.com/>, navigate to Downloads, Red Hat Enterprise Linux,

--- a/reference-architecture/rhv-ansible/ansible.cfg
+++ b/reference-architecture/rhv-ansible/ansible.cfg
@@ -6,7 +6,7 @@ inventory_ignore_extensions = .example, .ini, .pyc, .pem
 gathering = smart
 # Roles path assumes this repo is checked out to same directory as
 # https://github.com/oVirt/ovirt-ansible.git
-roles_path = ./playbooks/roles:../../roles:../../../ovirt-ansible/roles
+roles_path = ./playbooks/roles:../../roles:/etc/ansible/roles
 remote_user = root
 retry_files_enabled=False
 log_path=./ansible.log

--- a/reference-architecture/rhv-ansible/ocp-vars.yaml
+++ b/reference-architecture/rhv-ansible/ocp-vars.yaml
@@ -10,8 +10,21 @@ engine_cafile: ../ca.pem
 
 ##############################################################################
 ### Red Hat Virtualization VM Image
+
+## Overrides flow in this order:
+#    template_name > image_path > qcow_url
+# in other words, if a {{ template_name }} VM template already exists in RHV, no image will be checked.
+# If the image is already downloaded to {{ image_path }}, it will not be re-downloaded.
+
+## Name of template to create openshift nodes from
+template_name: rhel7
+
+## If you prefer to provide a pre-downloaded VM image instead, use an absolute path, e.g.:
+#image_path: /home/myuser/Downloads/{{ template_name }}.qcow2
+
 ## For CentOS 7:
 #qcow_url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+
 ## For RHEL: Find KVM Guest Image in Downloads -> RHEL on https://access.redhat.com/ and use before the link expires:
 #qcow_url:https://access.cdn.redhat.com//content/origin/files/<omitted>/rhel-server-7.4-x86_64-kvm.qcow2?_auth_=<omitted>
 ## Alternatively, download the above KVM image, and re-host it on a local satellite:

--- a/reference-architecture/rhv-ansible/playbooks/ovirt-vm-infra.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/ovirt-vm-infra.yaml
@@ -19,8 +19,8 @@
         - always
 
   roles:
-    - ovirt-image-template
-    - ovirt-vm-infra
+    - oVirt.image-template
+    - oVirt.vm-infra
 
   post_tasks:
     - name: Logout from oVirt

--- a/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
@@ -11,7 +11,6 @@ data_center_name: Default
 # VM infra
 ##########################
 template_cluster: "{{ rhv_cluster }}"
-template_name: rhel7
 template_memory: 8GiB
 template_cpu: 1
 template_disk_storage: "{{ rhv_data_storage }}"
@@ -23,7 +22,7 @@ template_nics:
 
 master_vm:
   cluster: "{{ rhv_cluster }}"
-  template: rhel7
+  template: "{{ template_name }}"
   memory: 16GiB
   cores: 2
   high_availability: true
@@ -35,7 +34,7 @@ master_vm:
 
 node_vm:
   cluster: "{{ rhv_cluster }}"
-  template: rhel7
+  template: "{{ template_name }}"
   memory: 8GiB
   cores: 2
   disks:

--- a/roles/deploy-host-nonpriv/tasks/main.yaml
+++ b/roles/deploy-host-nonpriv/tasks/main.yaml
@@ -10,13 +10,4 @@
     command: "ssh-keygen -N '' -f ~/.ssh/id_rsa"
     when: not ssh_key.stat.exists
   when: "'rhv' in provider or 'vsphere' in provider"
-
-# RHV needs an extra repo
-- name: Git clone required ovirt repo
-  git:
-    repo: https://github.com/ovirt/ovirt-ansible
-    dest: ~/git/ovirt-ansible
-    update: no
-  when: "'rhv' in provider"
-
 ...

--- a/roles/deploy-host/tasks/main.yaml
+++ b/roles/deploy-host/tasks/main.yaml
@@ -47,6 +47,8 @@
       yum: name={{item}} state=installed
       with_items:
         - "{{ openshift_deploy_packages_by_provider }}"
+    - name: "Install oVirt roles from Galaxy"
+      command: "ansible-galaxy install ovirt.ovirt-ansible-roles"
   when: "'rhv' in provider"
 
 - block:


### PR DESCRIPTION
#### What does this PR do?
oVirt roles have moved from a single GitHub repo to multiple role-centric repositories, and are [now available](https://ovirt.org/blog/2017/08/ovirt-ansible-roles-how-to-use/) through Ansible Galaxy and by RPM.
In this PR:

- Adjust the rhv-ansible refarch playbooks
- Adjust the rhv-ansible refarch ansible.cfg
- Adjust the rhv-ansible refarch README
- Adjust the deploy-hosts and deploy-hosts-nonpriv roles to install from Ansible Galaxy instead of checking out GitHub.

#### How should this be manually tested?
Test deploy-host playbook as mentioned in rhv-ansible README, then deploy VMs on a RHV cluster.

#### Is there a relevant Issue open for this?
- https://github.com/openshift/openshift-ansible-contrib/issues/908

#### Who would you like to review this?
cc: @cooktheryan @e-minguez @dav1x PTAL
