### PR TITLE
[RHSM] Add missing server url

### DIFF
--- a/roles/rhsm/tasks/main.yaml
+++ b/roles/rhsm/tasks/main.yaml
@@ -42,6 +42,7 @@
         username: "{{ rhsm_user | default(omit) }}"
         password: "{{ rhsm_password | default(omit) }}"
         pool: "{{ rhsm_pool | default(omit) }}"
+        server_hostname: "{{ rhsm_satellite | default(omit) }}"
       when:
         - "'not registered' in subscribed.stdout"
         - rhsm_user is defined


### PR DESCRIPTION
For the moment, if we want to use RHSM with username and password
AND custom serverl url, for example 'stage', then we fail.
In this case we go to the prod server with creds from the stage,
which is bug.
So, add server url to the appropriate task to make it work
with any server different from the default one (prod).

#### Is there a relevant Issue open for this?
https://github.com/openshift/openshift-ansible-contrib/issues/911

#### Who would you like to review this?
cc: @tomassedovic PTAL @dav1x @cooktheryan 
