### PR TITLE
[VMWare] Make sure ssh key is pulled in running add-node.py

### DIFF
--- a/reference-architecture/vmware-ansible/add-node.py
+++ b/reference-architecture/vmware-ansible/add-node.py
@@ -379,6 +379,14 @@ class VMWareAddNode(object):
             if not click.confirm('Continue adding nodes with these values?'):
                 sys.exit(0)
 
+        # grab the default priv key from the user"
+        command='cp -f ~/.ssh/id_rsa ssh_key/ocp-installer'
+        os.system(command)
+
+        # make sure the ssh keys have the proper permissions
+        command='chmod 600 ssh_key/ocp-installer'
+        os.system(command)
+
         if 'cns' in self.container_storage and 'storage' in self.node_type:
             if 'None' in self.tag:
                 # do the full install and config minus the cleanup


### PR DESCRIPTION
For the moment, from two python modules, which run ansible playbooks,
only one pulls in SSH key configured in ansible.cfg
It is 'ocp-on-vmware.py', but it should also be done in 'add-node.py'.
So, add the same logic in second module to avoid SSH connection errors
running 'add-node.py' module from other dirs/machines than
'ocp-on-vmware.py' had run on.

#### Is there a relevant Issue open for this?
https://github.com/openshift/openshift-ansible-contrib/issues/913

#### Who would you like to review this?
cc: @tomassedovic PTAL @dav1x @cooktheryan 
