### PR TITLE
Rhv docker reorder

### DIFF
--- a/reference-architecture/rhv-ansible/playbooks/library/rpm_q.py
+++ b/reference-architecture/rhv-ansible/playbooks/library/rpm_q.py
@@ -1,0 +1,1 @@
+/usr/share/ansible/openshift-ansible/library/rpm_q.py

--- a/reference-architecture/rhv-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/openshift-install.yaml
@@ -3,34 +3,44 @@
   gather_facts: yes
   roles:
     - instance-groups
-  tags:
-    - always
-
-- include: ../../../playbooks/prerequisite.yaml
-  tags:
-    - pre
-    - rhsm
 
 - hosts: nodes
+  gather_facts: yes
   roles:
+    - rhsm-timeout
+    - role: atomic-update
+      when: openshift.common.is_atomic
+
+- hosts: nodes
+  gather_facts: no
+  serial: 1
+  roles:
+    - role: rhsm-subscription
+      when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
+            ansible_distribution == "RedHat" and ( rhsm_user is defined or rhsm_activation_key is defined)
+
+- hosts: nodes
+  gather_facts: no
+  roles:
+    - role: rhsm-repos
+      when: deployment_type in ["enterprise", "atomic-enterprise", "openshift-enterprise"] and
+          ansible_distribution == "RedHat" and ( rhsm_user is defined or rhsm_activation_key is defined)
     - role: docker-storage-setup
       docker_dev: '/dev/vdb'
-  tags:
-    - pre
-    - storage
+    - prerequisites
+
+- hosts: masters
+  gather_facts: yes
+  roles:
+    - master-prerequisites
 
 - hosts: schedulable_nodes
   roles:
     - role: openshift-volume-quota
       local_volumes_device: '/dev/vdc'
-  tags:
-    - pre
-    - storage
 
 - name: call openshift includes for installer
   include: /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
-  tags:
-    - byo
   vars:
     debug_level: 2
     openshift_debug_level: "{{ debug_level }}"

--- a/reference-architecture/rhv-ansible/playbooks/output-dns.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/output-dns.yaml
@@ -20,7 +20,15 @@
         - inventory.nsupdate
         - inventory.hosts
     ###############################
-    # Create NSUPDATE entries Reverse first
+    # NSUPDATE
+    - name: Create NSUPDATE server line
+      lineinfile:
+        path: ../inventory.nsupdate
+        line: "server {{ nsupdate_server }}"
+        state: present
+      when: nsupdate_server is defined
+    ###############################
+    # Reverse entries
     - name: Create NSUPDATE reverse pointer entries
       lineinfile:
         path: ../inventory.nsupdate
@@ -31,6 +39,12 @@
         - "{{ groups['tag_openshift_infra'] }}"
         - "{{ groups['tag_openshift_node'] }}"
         - "{{ groups['tag_openshift_lb'] }}"
+    - name: Append show/send lines
+      lineinfile:
+        path: ../inventory.nsupdate
+        line: "show\nsend"
+        state: present
+      when: nsupdate_server is defined
     - name: Create NSUPDATE entries for public hosted zone
       lineinfile:
         path: ../inventory.nsupdate
@@ -56,6 +70,12 @@
         - "{{ groups['tag_openshift_infra'] }}"
         - "{{ groups['tag_openshift_node'] }}"
         - "{{ groups['tag_openshift_lb'] }}"
+    - name: Append show/send lines
+      lineinfile:
+        path: ../inventory.nsupdate
+        line: "show\nsend"
+        state: present
+      when: nsupdate_server is defined
     ###############################
     # Create HOST entries
     - name: Create HOSTS public hostname

--- a/roles/docker-storage-setup/tasks/main.yaml
+++ b/roles/docker-storage-setup/tasks/main.yaml
@@ -1,6 +1,7 @@
 ---
 - name: stop docker
   service: name=docker state=stopped
+  ignore_errors: yes
 
 - name: remove any existing docker-storage config file
   file:


### PR DESCRIPTION
#### What does this PR do?
Modifies OCP on RHV openshift-install playbook so it ensures proper order of operations for rhsm, docker setup, docker installation, and prerequisite installations.

Outside of `reference-architectures/rhv-ansible`, only `docker-storage-setup` is touched.

#### How should this be manually tested?
Run openshift-ansible playbook in a RHV environment.

#### Is there a relevant Issue open for this?
Found during testing of CentOS

#### Who would you like to review this?
cc: @cooktheryan @dav1x  PTAL
