### PR TITLE
Better Atomic support

### DIFF
--- a/roles/docker/library/openshift_facts.py
+++ b/roles/docker/library/openshift_facts.py
@@ -1,0 +1,1 @@
+/usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Gather facts
+  openshift_facts:
+    role: common
+
 - name: "Setting Docker Facts"
   set_fact:
     docker_storage_block_device: "{{ docker_storage_block_device | default(default_docker_storage_block_device) }}"
@@ -11,6 +15,7 @@
     update_cache: yes
   notify:
     - enable docker
+  when: not openshift.common.is_atomic
 
 - name: "Check for existing Docker Storage device"
   command: pvs

--- a/roles/hostnames/library/openshift_facts.py
+++ b/roles/hostnames/library/openshift_facts.py
@@ -1,0 +1,1 @@
+/usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py

--- a/roles/hostnames/tasks/main.yaml
+++ b/roles/hostnames/tasks/main.yaml
@@ -1,4 +1,8 @@
 ---
+- name: Gather facts
+  openshift_facts:
+    role: common
+
 - name: Setting Hostname Fact
   set_fact:
     new_hostname: "{{ custom_hostname | default(inventory_hostname_short) }}"
@@ -20,12 +24,12 @@
 - name: Setting hostname and DNS domain
   hostname: name="{{ new_fqdn }}"
   # Use the hostname module when not on RHEL 7.5 or on the version of Ansible that fixed the hostname module.
-  when: not rhel75 or hostname_module_fixed
+  when: (not rhel75 or hostname_module_fixed) and not openshift.common.is_atomic
 
 - name: Setting hostname and DNS domain using the command module
   command: "hostname {{ new_fqdn }}"
   # Use the command module when RHEL 7.5 or later, and when Ansible does not contain the hostname module fix.
-  when: rhel75 and not hostname_module_fixed
+  when: (rhel75 and not hostname_module_fixed) and not openshift.common.is_atomic
 
 - name: Check for cloud.cfg
   stat: path=/etc/cloud/cloud.cfg

--- a/roles/node-network-manager/library/openshift_facts.py
+++ b/roles/node-network-manager/library/openshift_facts.py
@@ -1,0 +1,1 @@
+/usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py

--- a/roles/node-network-manager/tasks/main.yml
+++ b/roles/node-network-manager/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
+- name: Gather facts
+  openshift_facts:
+    role: common
+
 - name: install NetworkManager
   package:
     name: NetworkManager
     state: present
+  when: not openshift.common.is_atomic
 
 - name: configure NetworkManager
   lineinfile:

--- a/roles/openshift-prep/library/openshift_facts.py
+++ b/roles/openshift-prep/library/openshift_facts.py
@@ -1,0 +1,1 @@
+/usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py

--- a/roles/openshift-prep/tasks/prerequisites.yml
+++ b/roles/openshift-prep/tasks/prerequisites.yml
@@ -1,26 +1,31 @@
 ---
+- name: Gather facts
+  openshift_facts:
+    role: common
+
 - name: "Cleaning yum repositories"
   command: "yum clean all"
+  when: not openshift.common.is_atomic
 
 - name: "Install required packages"
   yum:
     name: "{{ item }}"
     state: latest
   with_items: "{{ required_packages }}"
-  when: manage_packages|bool
+  when: (manage_packages|bool and not openshift.common.is_atomic)
 
 - name: "Install debug packages (optional)"
   yum:
     name: "{{ item }}"
     state: latest
   with_items: "{{ debug_packages }}"
-  when: install_debug_packages|bool
+  when: (install_debug_packages|bool and not it_atomic)
 
 - name: "Update all packages (this can take a very long time)"
   yum:
     name: '*'
     state: latest
-  when: manage_packages|bool
+  when: (manage_packages|bool and update_packages|bool and not openshift.common.is_atomic)
 
 - name: "Verify hostname"
   shell: hostnamectl status | awk "/Static hostname/"'{ print $3 }'
@@ -29,7 +34,7 @@
 - name: "Set hostname if required"
   hostname:
     name: "{{ ansible_fqdn }}"
-  when: hostname_fqdn.stdout != ansible_fqdn
+  when: hostname_fqdn.stdout != ansible_fqdn and not openshift.common.is_atomic
 
 - name: "Verify SELinux is enforcing"
   fail:

--- a/roles/subscription-manager/library/openshift_facts.py
+++ b/roles/subscription-manager/library/openshift_facts.py
@@ -1,0 +1,1 @@
+/usr/share/ansible/openshift-ansible/roles/openshift_facts/library/openshift_facts.py

--- a/roles/subscription-manager/tasks/main.yml
+++ b/roles/subscription-manager/tasks/main.yml
@@ -5,6 +5,10 @@
   when:
     - rhsm_password is not defined or rhsm_password is none or rhsm_password|trim == ''
 
+- name: Gather facts
+  openshift_facts:
+    role: common
+
 - name: "Initializing Subscription Manager authentication method"
   set_fact:
     rhsm_authentication: false
@@ -64,6 +68,26 @@
     - rhsm_satellite is defined
     - rhsm_satellite is not none
     - rhsm_satellite|trim != ''
+    - not openshift.common.is_atomic
+- name: Manually configure satellite on Atomic"
+  get_url:
+    url: http://{{ rhsm_satellite }}/pub/katello-rhsm-consumer
+    dest: /usr/local/bin/katello-rhsm-consumer
+    mode: 755
+  when:
+    - not registered
+    - rhsm_satellite is defined
+    - rhsm_satellite is not none
+    - rhsm_satellite|trim != ''
+    - openshift.common.is_atomic
+- name: Manually run RHSM configuration script on Atomic
+  command: /usr/local/bin/katello-rhsm-consumer
+  when:
+    - not registered
+    - rhsm_satellite is defined
+    - rhsm_satellite is not none
+    - rhsm_satellite|trim != ''
+    - openshift.common.is_atomic
 
 - name: "Register to Satellite using activation key"
   command: "/usr/bin/subscription-manager register --activationkey={{ rhsm_activationkey }} --org='{{ rhsm_org }}'"


### PR DESCRIPTION
What does this PR do?
When running the playbook "playbooks/provisioning/openstack/provision.yaml" against Atomic hosts (RHEL 7.4 in my case), commands such yum update, yum clean etc where failing due to the fact that yum doesn't exists.
An "update_packages" switch has been added to skip the update of the OS.
Also the subscription managed has been enhanced for better support of Atomic OS

How should this be manually tested?
Configure nodes and/or infra to use Atomic OS

Who would you like to review this?
cc: @tomassedovic PTAL