### PR TITLE
Added support of OpenStack LBaaS

### DIFF
--- a/roles/dns-records/tasks/main.yml
+++ b/roles/dns-records/tasks/main.yml
@@ -47,6 +47,15 @@
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openstack_num_masters > 1
+    - openstack_lb != "external"
+
+- name: "Add public master cluster hostname records to the private A records (multi-master) external loadbalancer"
+  set_fact:
+    private_records: "{{ private_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone_private, ''))[:-1], 'ip': external_loadbalancer_master['private_v4'] } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters > 1
+    - openstack_lb == "external"
 
 - name: "Generate the private Add section for DNS"
   set_fact:
@@ -96,6 +105,15 @@
     - openshift_master_default_subdomain is defined
     - openshift_master_default_subdomain|trim != ''
     - hostvars[item]['public_v4'] is defined
+    - external_loadbalancer_app is not defined
+
+- name: "Add wildcard records to the public A records external loadbalancer"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': '*.' + (openshift_master_default_subdomain | replace('.' + nsupdate_zone_public, '')), 'ip': external_loadbalancer_app['public_v4'] } ] }}"
+  when:
+    - openshift_master_default_subdomain is defined
+    - openshift_master_default_subdomain|trim != ''
+    - external_loadbalancer_app is defined
 
 - name: "Add public master cluster hostname records to the public A records (single master)"
   set_fact:
@@ -119,6 +137,15 @@
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
     - openstack_num_masters > 1
+    - openstack_lb != "external"
+- name: "Add public master cluster hostname records to the public A records (multi-master) external loadbalancer"
+  set_fact:
+    public_records: "{{ public_records | default([]) + [ { 'type': 'A', 'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone_public, ''))[:-1], 'ip': external_loadbalancer_master['public_v4'] } ] }}"
+  when:
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
+    - openstack_num_masters > 1
+    - openstack_lb == "external"
+    - external_loadbalancer_master is defined
 
 - name: "Generate the public Add section for DNS"
   set_fact:

--- a/roles/openstack-stack/files/lbaas_member.yaml
+++ b/roles/openstack-stack/files/lbaas_member.yaml
@@ -1,0 +1,34 @@
+heat_template_version: 2016-10-14
+
+description: OpenShift LBaaS member
+
+parameters:
+  ip_v4s:
+    type: comma_delimited_list
+    description: List of IPs
+    label: list_of_members_ip
+  pool:
+    type: string
+    description: Pool ID
+    label: pool_id
+  subnet:
+    type: string
+    description: Subnet ID
+    label: subnet_id
+  protocol_port:
+    type: string
+    description: Protocol Port
+    label: protocol_port
+  index: 
+    type: number 
+    description: Index into ips list 
+    label: index 
+
+resources:
+  pool_member:
+    type: OS::Neutron::LBaaS::PoolMember
+    properties:
+      pool: { get_param: pool }
+      address: { get_param: [ip_v4s, { get_param: index } ] } 
+      subnet: { get_param: subnet }
+      protocol_port: { get_param: protocol_port }

--- a/roles/openstack-stack/tasks/generate-templates.yml
+++ b/roles/openstack-stack/tasks/generate-templates.yml
@@ -10,6 +10,11 @@
     stack_template_path: "{{ stack_template_pre.path }}/stack.yaml"
     user_data_template_path: "{{ stack_template_pre.path }}/user-data"
 
+- name: Copy LBaaS Member files
+  copy:
+    src: files/lbaas_member.yaml
+    dest: "{{ stack_template_pre.path }}/lbaas_member.yaml"
+
 - name: generate HOT stack template from jinja2 template
   template:
     src: heat_stack.yaml.j2

--- a/roles/openstack-stack/tasks/main.yml
+++ b/roles/openstack-stack/tasks/main.yml
@@ -13,7 +13,6 @@
     state: "{{ stack_state }}"
     template: "{{ stack_template_path | default(omit) }}"
     wait: yes
-
 # NOTE(bogdando) OS::Neutron::Subnet doesn't support live updates for
 # dns_nameservers, so we can't do that for the "create stack" task.
 - include: subnet_update_dns_servers.yaml

--- a/roles/openstack-stack/templates/heat_stack.yaml.j2
+++ b/roles/openstack-stack/templates/heat_stack.yaml.j2
@@ -3,7 +3,6 @@ heat_template_version: 2016-10-14
 description: OpenShift cluster
 
 parameters:
-
 outputs:
 
   etcd_names:
@@ -53,6 +52,29 @@ outputs:
   infra_floating_ips:
     description: Floating IPs of the nodes
     value: { get_attr: [ infra_nodes, floating_ip ] }
+{% if openstack_lb == 'external' and num_masters|int > 1 %}
+  external_lb_master_floatingip:
+   description: IP of master LB in multimaster mode
+   value: { get_attr: [ external_lb_master_floating_ip, floating_ip_address ] }
+{% endif %}
+
+{% if openstack_lb == 'external' %}
+  loadbalancer_ip:
+    description: LBaaS IP
+    value: { get_attr: [ external_lb_app_floating_ip, floating_ip_address ] }
+{% endif %}
+  console_url:
+    description: URL of the console
+    value: https://console.{{ stack_name }}:{{ openshift_master_console_port|default(8443) }}
+  console_ip:
+    description: IP of the console
+{% if num_masters|int > 1 and openstack_lb != 'external'%}
+    value: { get_attr: [ loadbalancer, resource.0.floating_ip ] } 
+{% elif num_masters|int > 1 and openstack_lb == 'external' %}
+    value: { get_attr: [ external_lb_master_floating_ip, floating_ip_address ] }
+{% else %}
+    value: { get_attr: [ masters, resource.0.floating_ip ] }    
+{% endif %}
 
 {% if num_dns|int > 0 %}
   dns_name:
@@ -75,6 +97,15 @@ conditions:
   no_floating: {% if provider_network or use_bastion|bool %}true{% else %}false{% endif %}
 
 resources:
+  sec_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: lbaas_sg
+      rules:
+      - remote_ip_prefix: 0.0.0.0/0
+        protocol: tcp
+        port_range_min: 80
+        port_range_max: 80
 
 {% if not provider_network %}
   net:
@@ -148,6 +179,167 @@ resources:
     properties:
       router_id: { get_resource: router }
       subnet_id: { get_resource: subnet }
+
+{% endif %}
+{% if openstack_lb == 'external' and num_masters|int > 1 %}
+  external_lb_master:
+    depends_on:
+      - subnet
+      - router
+    type: OS::Neutron::LBaaS::LoadBalancer
+    properties:
+      name: lb-master-{{ stack_name }}
+      vip_subnet: { get_resource: subnet }
+
+  external_lb_master_api_listener_https:
+    depends_on: external_lb_master
+    type: OS::Neutron::LBaaS::Listener
+    properties:
+      loadbalancer: { get_resource: external_lb_master }
+      protocol: HTTPS
+      protocol_port: {{ openshift_master_api_port|default(8443) }}
+
+  external_lb_master_api_pool_https:
+    depends_on: external_lb_master_api_listener_https
+    type: OS::Neutron::LBaaS::Pool
+    properties:
+      lb_algorithm: ROUND_ROBIN
+      protocol: HTTPS
+      listener: { get_resource: external_lb_master_api_listener_https}
+
+  external_lb_master_floating_ip:
+    depends_on: router
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {{ external_network }}
+      port_id: { get_attr: [external_lb_master, vip_port_id ]}
+
+  external_lb_masters_api_members:
+    depends_on: external_lb_master_api_pool_https
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: {{ num_masters }}
+      resource_def:
+        type: lbaas_member.yaml
+        properties:
+          index: "%index%"
+          pool: { get_resource: external_lb_master_api_pool_https }
+          ip_v4s: { get_attr: [ masters, private_ip ] }
+          subnet: { get_resource: subnet }
+          protocol_port: {{ openshift_master_api_port|default(8443) }}
+
+
+{% if openshift_master_console_port|default(8443) != openshift_master_api_port|default(8443) %}
+  external_lb_master_console_listener_https:
+    depends_on: external_lb_master
+    type: OS::Neutron::LBaaS::Listener
+    properties:
+      loadbalancer: { get_resource: external_lb_master }
+      protocol: HTTPS
+      protocol_port: {{ openshift_master_console_port|default(8443) }}
+
+  external_lb_master_console_pool_https:
+    depends_on: external_lb_master_console_listener_https
+    type: OS::Neutron::LBaaS::Pool
+    properties:
+      lb_algorithm: ROUND_ROBIN
+      protocol: HTTPS
+      listener: { get_resource: external_lb_master_console_listener_https}
+
+  external_lb_masters_console_members:
+    depends_on: external_lb_master_console_pool_https
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: {{ num_masters }}
+      resource_def:
+        type: lbaas_member.yaml
+        properties:
+          index: "%index%"
+          pool: { get_resource: external_lb_master_console_pool_https }
+          ip_v4s: { get_attr: [ masters, private_ip ] }
+          subnet: { get_resource: subnet }
+          protocol_port: {{ openshift_master_console_port|default(8443) }}
+{% endif %}
+
+
+{% endif %}
+
+{% if openstack_lb == 'external' %}
+  external_lb_app:
+    depends_on:
+      - subnet
+      - router
+    type: OS::Neutron::LBaaS::LoadBalancer
+    properties:
+      name: lb-apps-{{ stack_name }}
+      vip_subnet: { get_resource: subnet }
+
+  external_lb_app_listener_http:
+    depends_on: external_lb_app
+    type: OS::Neutron::LBaaS::Listener
+    properties:
+      loadbalancer: { get_resource: external_lb_app }
+      protocol: HTTP
+      protocol_port: 80
+
+  external_lb_app_listener_https:
+    depends_on: external_lb_app
+    type: OS::Neutron::LBaaS::Listener
+    properties:
+      loadbalancer: { get_resource: external_lb_app }
+      protocol: HTTPS
+      protocol_port: 443
+
+  external_lb_app_pool_http:
+    depends_on: external_lb_app_listener_http
+    type: OS::Neutron::LBaaS::Pool
+    properties:
+      lb_algorithm: ROUND_ROBIN
+      protocol: HTTP
+      listener: { get_resource: external_lb_app_listener_http }
+
+  external_lb_app_pool_https:
+    depends_on: external_lb_app_listener_https
+    type: OS::Neutron::LBaaS::Pool
+    properties:
+      lb_algorithm: ROUND_ROBIN
+      protocol: HTTPS
+      listener: { get_resource: external_lb_app_listener_https }
+
+  external_lb_app_http_members:
+    depends_on: external_lb_app_pool_http
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: {{ num_infra }}
+      resource_def:
+        type: lbaas_member.yaml
+        properties:
+          index: "%index%"
+          pool: { get_resource: external_lb_app_pool_http }
+          ip_v4s: { get_attr: [ infra_nodes, private_ip ] }
+          subnet: { get_resource: subnet }
+          protocol_port: 80
+
+  external_lb_app_https_members:
+    depends_on: external_lb_app_pool_https
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: {{ num_infra }}
+      resource_def:
+        type: lbaas_member.yaml
+        properties:
+          index: "%index%"
+          pool: { get_resource: external_lb_app_pool_https }
+          ip_v4s: { get_attr: [ infra_nodes, private_ip ] }
+          subnet: { get_resource: subnet }
+          protocol_port: 443
+
+  external_lb_app_floating_ip:
+    depends_on: router
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {{ external_network }}
+      port_id: { get_attr: [external_lb_app, vip_port_id ]}
 
 {% endif %}
 
@@ -577,6 +769,7 @@ resources:
       policies: {{ infra_server_group_policies }}
 {% endif %}
 {% if num_masters|int > 1 %}
+{% if openstack_lb != 'external' %}
   loadbalancer:
     type: OS::Heat::ResourceGroup
     properties:
@@ -624,6 +817,7 @@ resources:
 {% if not provider_network %}
     depends_on:
       - interface
+{% endif %}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
#### What does this PR do?
When setting "openstack_lb: external", the heat script will create a LBaaS neutron V2 instance with private IPs of infra nodes as members.
If the number of master is greater than 1 (multi-masters), another instance of LBaaS will be created with masters private IPs as members.

#### Who would you like to review this?
cc: @tomassedovic PTAL
