### PR TITLE
Switch from Galaxy to RPM for installing oVirt Ansible roles

### DIFF
--- a/reference-architecture/rhv-ansible/README.md
+++ b/reference-architecture/rhv-ansible/README.md
@@ -28,10 +28,9 @@ $ cd ~/git/openshift-ansible-contrib && ansible-playbook playbooks/deploy-host.y
 ```
 
 ### oVirt Ansible roles
-[oVirt Ansible roles](https://github.com/ovirt/ovirt-ansible) will be installed from
-[Ansible Galaxy](https://galaxy.ansible.com/)
-into your system's Ansible role path, typically `/etc/ansible/roles`. These are required for playbooks to interact
-with RHV to create VMs.
+[oVirt Ansible roles](https://github.com/ovirt/ovirt-ansible) will be installed
+into your system's Ansible role path, typically `/usr/share/ansible/roles`.
+These are required for playbooks to interact with RHV/oVirt to create VMs.
 
 ### Dynamic Inventory
 A copy of `ovirt4.py` from the Ansible project is provided under the inventory directory. This script will, given credentials to a RHV 4 engine, populate the Ansible inventory with facts about all virtual machines in the cluster. In order to use this dynamic inventory, see the `ovirt.ini.example` file, either providing the relevant Python secrets via environment variables, or by copying it to `ovirt.ini` and filling in the values.

--- a/reference-architecture/rhv-ansible/ansible.cfg
+++ b/reference-architecture/rhv-ansible/ansible.cfg
@@ -4,9 +4,9 @@ host_key_checking = False
 inventory = inventory/
 inventory_ignore_extensions = .example, .ini, .pyc, .pem
 gathering = smart
-# Roles path assumes this repo is checked out to same directory as
-# https://github.com/oVirt/ovirt-ansible.git
-roles_path = ./playbooks/roles:../../roles:/etc/ansible/roles
+# Roles path assumes oVirt-ansible roles installed to /usr/share/ansible/roles via RPM
+# per instructions at:  https://github.com/oVirt/ovirt-ansible
+roles_path = ./playbooks/roles:../../roles:/usr/share/ansible/roles
 remote_user = root
 retry_files_enabled=False
 log_path=./ansible.log

--- a/roles/deploy-host/tasks/main.yaml
+++ b/roles/deploy-host/tasks/main.yaml
@@ -39,16 +39,17 @@
       command: "subscription-manager repos --enable=rhel-7-server-rhv-4-mgmt-agent-rpms"
       when: "'rhv' not in enabled_repos.stdout"
 
+    - name: "Enable oVirt repository"
+      command: 'yum -y install http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm'
+
     - name: "Establish rhv pre-req packages"
       set_fact:
-        openshift_deploy_packages_by_provider: ['python-ovirt-engine-sdk4']
+        openshift_deploy_packages_by_provider: ['python-ovirt-engine-sdk4', 'ovirt-ansible-roles']
 
     - name: "Be sure all pre-req rhv packages are installed"
       yum: name={{item}} state=installed
       with_items:
         - "{{ openshift_deploy_packages_by_provider }}"
-    - name: "Install oVirt roles from Galaxy"
-      command: "ansible-galaxy install ovirt.ovirt-ansible-roles"
   when: "'rhv' in provider"
 
 - block:


### PR DESCRIPTION
#### What does this PR do?
Changes deploy-host role from Ansible Galaxy to RPM for install of necessary oVirt Ansible roles in RHV provider.

#### How should this be manually tested?
Run deploy host playbook for rhv provider then ensure that ovirt controls work as intended.

#### Is there a relevant Issue open for this?
Recommended in discussion with RHV principals

#### Who would you like to review this?
cc: @cooktheryan @dav1x 