### PR TITLE
Don't register change when gathering information

### DIFF
--- a/roles/rhsm-repos/tasks/main.yaml
+++ b/roles/rhsm-repos/tasks/main.yaml
@@ -3,6 +3,7 @@
     - name: "Obtain currently enabled repos"
       shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
       register: enabled_repos
+      changed_when: no
 
     - name: "Disable repositories that should not be enabled"
       shell: "subscription-manager repos --disable={{ item }}"

--- a/vagrant/install.yaml
+++ b/vagrant/install.yaml
@@ -4,6 +4,7 @@
   tasks:
   - command: find /home/vagrant/sync/vagrant/.vagrant/machines -name private_key
     register: private_keys
+    changed_when: no
 
   - file:
       src: "{{ item }}"


### PR DESCRIPTION
#### What does this PR do?

When provisioning Vagrant VM's, the Ansible playbook gathers some information from the host using the "command" module. As a result, these tasks always register as a change. This PR fixes that.
