### PR TITLE
Property for disk type (tier) added

### DIFF
--- a/reference-architecture/gcp/ansible/playbooks/openshift-post.yaml
+++ b/reference-architecture/gcp/ansible/playbooks/openshift-post.yaml
@@ -13,9 +13,9 @@
   roles:
   - role: openshift_default_storage_class
     openshift_storageclass_default: false
-    openshift_storageclass_name: ssd
+    openshift_storageclass_name: gcp-default
     openshift_storageclass_parameters:
-      type: pd-ssd
+      type: {{ properties['disk_type'] }}
   tasks:
   - name: gather facts
     openshift_facts:

--- a/reference-architecture/gcp/config.yaml.example
+++ b/reference-architecture/gcp/config.yaml.example
@@ -90,6 +90,8 @@ openshift_master_identity_providers:
 ### Supplemental options ###
 ###
 
+# Disk types
+gcloud_disk_type: pd-ssd
 
 # Disk sizes in GB
 bastion_disk_size: 20

--- a/reference-architecture/gcp/deployment-manager/core-config.yaml.j2
+++ b/reference-architecture/gcp/deployment-manager/core-config.yaml.j2
@@ -11,6 +11,7 @@ resources:
     gold_image: {{ gold_image_family }}
     console_port: {{ console_port }}
     containerized: {{ containerized }}
+    disk_type: {{ gcloud_disk_type }}
     bastion_machine_type: {{ bastion_machine_type }}
     bastion_disk_size: {{ bastion_disk_size }}
     master_machine_type: {{ master_machine_type }}

--- a/reference-architecture/gcp/deployment-manager/core.jinja
+++ b/reference-architecture/gcp/deployment-manager/core.jinja
@@ -9,7 +9,7 @@ resources:
       initializeParams:
         sourceImage: global/images/family/{{ properties['gold_image'] }}
         diskSizeGb: {{ properties['bastion_disk_size'] }}
-        diskType: zones/{{ properties['zone'] }}/diskTypes/pd-ssd
+        diskType: zones/{{ properties['zone'] }}/diskTypes/{{ properties['disk_type'] }}
     machineType: zones/{{ properties['zone'] }}/machineTypes/{{ properties['bastion_machine_type'] }}
     metadata: {}
     networkInterfaces:
@@ -52,7 +52,7 @@ resources:
         initializeParams:
           diskSizeGb: {{ properties['master_boot_disk_size'] }}
           sourceImage: global/images/family/{{ properties['gold_image'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       {% if properties['containerized'] %}
       - autoDelete: true
         boot: false
@@ -61,7 +61,7 @@ resources:
         initializeParams:
           sourceImage: global/images/empty-1g
           diskSizeGb: {{ properties['master_docker_disk_size'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       {% endif %}
       machineType: {{ properties['master_machine_type'] }}
       metadata:
@@ -124,7 +124,7 @@ resources:
         initializeParams:
           diskSizeGb: {{ properties['infra_boot_disk_size'] }}
           sourceImage: global/images/family/{{ properties['gold_image'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       - autoDelete: true
         boot: false
         index: 1
@@ -132,7 +132,7 @@ resources:
         initializeParams:
           sourceImage: global/images/empty-1g
           diskSizeGb: {{ properties['infra_docker_disk_size'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       - autoDelete: true
         boot: false
         index: 2
@@ -140,7 +140,7 @@ resources:
         initializeParams:
           sourceImage: global/images/empty-1g
           diskSizeGb: {{ properties['infra_openshift_disk_size'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       machineType: {{ properties['infra_machine_type'] }}
       metadata:
         items:
@@ -207,7 +207,7 @@ resources:
         initializeParams:
           diskSizeGb: {{ properties['node_boot_disk_size'] }}
           sourceImage: global/images/family/{{ properties['gold_image'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       - autoDelete: true
         boot: false
         index: 1
@@ -215,7 +215,7 @@ resources:
         initializeParams:
           sourceImage: global/images/empty-1g
           diskSizeGb: {{ properties['node_docker_disk_size'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       - autoDelete: true
         boot: false
         index: 2
@@ -223,7 +223,7 @@ resources:
         initializeParams:
           sourceImage: global/images/empty-1g
           diskSizeGb: {{ properties['node_openshift_disk_size'] }}
-          diskType: pd-ssd
+          diskType: {{ properties['disk_type'] }}
       machineType: {{ properties['node_machine_type'] }}
       metadata:
         items:

--- a/reference-architecture/gcp/deployment-manager/tmp-instance.jinja
+++ b/reference-architecture/gcp/deployment-manager/tmp-instance.jinja
@@ -12,7 +12,7 @@ resources:
       initializeParams:
         sourceImage: {{ properties['source_family'] }}
         diskSizeGb: 10
-        diskType: zones/{{ properties['zone'] }}/diskTypes/pd-ssd
+        diskType: zones/{{ properties['zone'] }}/diskTypes/{{ properties['disk_type'] }}
     machineType: zones/{{ properties['zone'] }}/machineTypes/n1-standard-1
     metadata: {}
     networkInterfaces:


### PR DESCRIPTION
#### What does this PR do?
Now, config can select the tier-ing for disks

#### How should this be manually tested?
Just with ocp-on-gcp.sh --infra should work

#### Is there a relevant Issue open for this?
Internal RFE

#### Who would you like to review this?
cc: @pschiffe 
