### PR TITLE
Reworked deploy-host role to work on CentOS hosts

### DIFF
--- a/roles/deploy-host/tasks/main.yaml
+++ b/roles/deploy-host/tasks/main.yaml
@@ -1,20 +1,4 @@
 ---
-- name: "Obtain currently enabled repos"
-  shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
-  register: enabled_repos
-
-- name: "Enable specified repositories not already enabled"
-  command: "subscription-manager repos --enable={{ item }}"
-  with_items:
-    - "{{ openshift_deploy_repos | difference(enabled_repos.stdout_lines) }}"
-  register: subscribe_repos
-  until: subscribe_repos | succeeded
-
-- name: "Be sure all pre-req provider packages are installed"
-  yum: name={{item}} state=installed
-  with_items:
-    - "{{ openshift_deploy_packages }}"
-
 - block:
     - name: "Establish gcp pre-req packages"
       set_fact:
@@ -24,51 +8,33 @@
       set_fact:
         openshift_deploy_epel_packages_by_provider: ['python2-libcloud', 'python2-jmespath']
 
-    - name: "Be sure all pre-req gcp packages are installed"
-      yum: name={{item}} state=installed
-      with_items:
-        - "{{ openshift_deploy_packages_by_provider }}"
   when: "'gcp' in provider"
 
 - block:
-    - name: "Obtain currently enabled repos for rhv"
-      shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
-      register: enabled_repos
-
-    - name: "Enable rhv mgmt repo for rhv"
-      command: "subscription-manager repos --enable=rhel-7-server-rhv-4-mgmt-agent-rpms"
-      when: "'rhv' not in enabled_repos.stdout"
+    - name: "Add RHV mgmt repo for rhv"
+      set_fact:
+        openshift_deploy_repos: "{{ openshift_deploy_repos }} + [ 'rhel-7-server-rhv-4-mgmt-agent-rpms' ]"
+      when: "'rhv' not in openshift_deploy_repos"
 
     - name: "Enable oVirt repository"
       command: 'yum -y install http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm'
+      when: not '/etc/yum.repos.d/ovirt-4.2.repo'|exists
 
     - name: "Establish rhv pre-req packages"
       set_fact:
         openshift_deploy_packages_by_provider: ['python-ovirt-engine-sdk4', 'ovirt-ansible-roles']
 
-    - name: "Be sure all pre-req rhv packages are installed"
-      yum: name={{item}} state=installed
-      with_items:
-        - "{{ openshift_deploy_packages_by_provider }}"
   when: "'rhv' in provider"
 
 - block:
-    - name: "Obtain currently enabled repos for vsphere"
-      shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
-      register: enabled_repos
-
-    - name: "Enable SCL Repo for vsphere"
-      command: "subscription-manager repos --enable=rhel-server-rhscl-7-rpms"
-      when: "'rhscl' not in enabled_repos.stdout"
+    - name: "Add SCL Repo for vsphere"
+      set_fact:
+        openshift_deploy_repos: "{{ openshift_deploy_repos }} + [ 'rhel-server-rhscl-7-rpms' ]"
+      when: "'rhscl' not in openshift_deploy_repos"
 
     - name: "Set facts for vsphere non EPEL packages"
       set_fact:
         openshift_deploy_packages_by_provider: ['python-click', 'python-ldap', 'python27']
-
-    - name: "Be sure all vsphere pre-req provider packages are installed"
-      yum: name={{item}} state=installed
-      with_items:
-        - "{{ openshift_deploy_packages_by_provider }}"
 
     - name: "Set facts for vsphere EPEL packages"
       set_fact:
@@ -82,6 +48,31 @@
   when: "'aws' in provider"
 
 - block:
+    - name: "Obtain currently enabled repos"
+      shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
+      register: enabled_repos
+
+    - name: "Enable specified repositories not already enabled"
+      command: "subscription-manager repos --enable={{ item }}"
+      with_items:
+        - "{{ openshift_deploy_repos | difference(enabled_repos.stdout_lines) }}"
+      register: subscribe_repos
+      until: subscribe_repos | succeeded
+
+    - name: "Obtain updated list of currently enabled repos"
+      shell: 'subscription-manager repos --list-enabled | sed -ne "s/^Repo ID:[^a-zA-Z0-9]*\(.*\)/\1/p"'
+      register: enabled_repos
+
+  when: ansible_distribution == "RedHat"
+
+- block:
+    - name: Enable OpenShift Origin repo for Centos
+      yum:
+        name: centos-release-openshift-origin37
+        state: installed
+  when: ansible_distribution == "CentOS"
+
+- block:
     - name: Check if EPEL repo is already configured.
       stat: path={{ epel_repofile_path }}
       register: epel_repofile_result
@@ -89,7 +80,7 @@
     - name: Install EPEL repo.
       yum:
         name: "{{ epel_repo_url }}"
-        state: present
+        state: installed
       register: result
       until: '"failed" not in result'
       retries: 5
@@ -107,4 +98,19 @@
       yum: name={{item}} state=installed
       with_items:
         - "{{ openshift_deploy_epel_packages_by_provider }}"
-  when: "'vsphere' in provider or 'aws' in provider or 'gcp' in provider"
+  when: openshift_deploy_epel_packages_by_provider is defined and openshift_deploy_epel_packages_by_provider
+
+- name: "Be sure all pre-req provider packages are installed"
+  yum:
+    name: "{{item}}"
+    state: installed
+  with_items:
+    - "{{ openshift_deploy_packages }}"
+
+- name: "Install provider specific prerequisite packages"
+  yum:
+    name: "{{item}}"
+    state: installed
+  with_items:
+    - "{{ openshift_deploy_packages_by_provider }}"
+  when: openshift_deploy_packages_by_provider is defined


### PR DESCRIPTION
#### What does this PR do?
  - Rearranged enablement of repositories to perform step once
  - Rearranged installation of packages to perform step once
  - Provider specific repos are appended to required repos
  - Centos hosts will install openshift origin release repo
  - Logic added to avoid running subscription-manager on non RHEL

#### How should this be manually tested?
Set up a workstation host using CentOS or RHEL and run playbook for provider.

Tested:
CentOS/rhv

RHEL/{rhv,aws,gcp,ocp,vsphere}

#### Is there a relevant Issue open for this?
Request by @mykaul to enable proper handling of CentOS in `deploy-host` playbook

#### Who would you like to review this?
cc: @dav1x @cooktheryan @mykaul PTAL
