### PR TITLE
GCP Ref. Arch.: add the possibility to attach to an existing VPC

### DIFF
--- a/reference-architecture/gcp/config.yaml.example
+++ b/reference-architecture/gcp/config.yaml.example
@@ -105,3 +105,9 @@ node_openshift_disk_size: 50
 # Custom VPC Subnet, example value: '10.160.0.0/20'
 # Default value is empty, when random subnet in form of 10.x.0.0/20 will be used
 gce_vpc_custom_subnet_cidr: ''
+
+# Custom VPC
+# If default empty value is left, a dedicated VPC will be created.
+# If a VPC is specified, the VMs will be attached to that pre-existing VPC.
+gce_custom_vpc_network: ''
+gce_custom_vpc_subnet: ''

--- a/reference-architecture/gcp/deployment-manager/core-config.yaml.j2
+++ b/reference-architecture/gcp/deployment-manager/core-config.yaml.j2
@@ -29,3 +29,5 @@ resources:
     node_instance_group_size: {{ node_instance_group_size }}
     gcs_registry_bucket: {{ gcs_registry_bucket }}
     gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr }}
+    gce_custom_vpc_network: {{ gce_custom_vpc_network }}
+    gce_custom_vpc_subnet: {{ gce_custom_vpc_subnet }}

--- a/reference-architecture/gcp/deployment-manager/core.jinja
+++ b/reference-architecture/gcp/deployment-manager/core.jinja
@@ -1,3 +1,12 @@
+{% if properties['gce_custom_vpc_network'] %}
+{% set network = properties['gce_custom_vpc_network'] %}
+{% set subnet = properties['gce_custom_vpc_subnet'] %}
+{% else %}
+{% set network = properties['prefix'] + '-network' %}
+{% if properties['gce_vpc_custom_subnet_cidr'] %}
+{% set subnet = properties['prefix'] + '-' + properties['region'] + '-subnet' %}
+{% endif %}
+{% endif %}
 resources:
 - name: {{ properties['prefix'] }}-bastion
   properties:
@@ -17,9 +26,9 @@ resources:
       - name: external-nat
         type: ONE_TO_ONE_NAT
       name: nic0
-      network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
-      {% if properties['gce_vpc_custom_subnet_cidr'] %}
-      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+      network: projects/{{env['project']}}/global/networks/{{ network }}
+      {% if subnet %}
+      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ subnet }}
       {% endif %}
     scheduling:
       automaticRestart: true
@@ -90,9 +99,9 @@ resources:
       - accessConfigs:
         - name: external-nat
           type: ONE_TO_ONE_NAT
-        network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
-        {% if properties['gce_vpc_custom_subnet_cidr'] %}
-        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        network: projects/{{env['project']}}/global/networks/{{ network }}
+        {% if subnet %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ subnet }}
         {% endif %}
       scheduling:
         automaticRestart: true
@@ -173,9 +182,9 @@ resources:
       - accessConfigs:
         - name: external-nat
           type: ONE_TO_ONE_NAT
-        network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
-        {% if properties['gce_vpc_custom_subnet_cidr'] %}
-        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        network: projects/{{env['project']}}/global/networks/{{ network }}
+        {% if subnet %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ subnet }}
         {% endif %}
       scheduling:
         automaticRestart: true
@@ -256,9 +265,9 @@ resources:
       - accessConfigs:
         - name: external-nat
           type: ONE_TO_ONE_NAT
-        network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
-        {% if properties['gce_vpc_custom_subnet_cidr'] %}
-        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+        network: projects/{{env['project']}}/global/networks/{{ network }}
+        {% if subnet %}
+        subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ subnet }}
         {% endif %}
       scheduling:
         automaticRestart: true

--- a/reference-architecture/gcp/deployment-manager/network-config.yaml.j2
+++ b/reference-architecture/gcp/deployment-manager/network-config.yaml.j2
@@ -8,3 +8,5 @@ resources:
     region: {{ gcloud_region }}
     console_port: {{ console_port }}
     gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr }}
+    gce_custom_vpc_network: {{ gce_custom_vpc_network }}
+    gce_custom_vpc_subnet: {{ gce_custom_vpc_subnet }}

--- a/reference-architecture/gcp/deployment-manager/network.jinja
+++ b/reference-architecture/gcp/deployment-manager/network.jinja
@@ -1,4 +1,8 @@
 resources:
+{% if properties['gce_custom_vpc_network'] %}
+{% set network = 'projects/' + env['project'] + '/global/networks/' + properties['gce_custom_vpc_network'] %}
+{% else %}
+{% set network = '$(ref.' + properties['prefix'] + '-network.selfLink)' %}
 - name: {{ properties['prefix'] }}-network
   properties:
   {% if properties['gce_vpc_custom_subnet_cidr'] %}
@@ -12,16 +16,17 @@ resources:
   properties:
     ipCidrRange: {{ properties['gce_vpc_custom_subnet_cidr'] }}
     privateIpGoogleAccess: true
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     region: {{ properties['region'] }}
   type: compute.v1.subnetwork
+{% endif %}
 {% endif %}
 - name: {{ properties['prefix'] }}-icmp
   properties:
     allowed:
     - IPProtocol: icmp
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceRanges:
     - 0.0.0.0/0
   type: compute.v1.firewall
@@ -32,7 +37,7 @@ resources:
       ports:
       - '22'
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceRanges:
     - 0.0.0.0/0
     targetTags:
@@ -45,7 +50,7 @@ resources:
       ports:
       - '22'
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceTags:
     - {{ properties['prefix'] }}-bastion
   type: compute.v1.firewall
@@ -59,7 +64,7 @@ resources:
       ports:
       - '8053'
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceTags:
     - {{ properties['prefix'] }}
     targetTags:
@@ -75,7 +80,7 @@ resources:
       ports:
       - '2380'
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceTags:
     - {{ properties['prefix'] }}-master
     targetTags:
@@ -88,7 +93,7 @@ resources:
       ports:
       - {{ properties['console_port'] }}
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceRanges:
     - 0.0.0.0/0
     targetTags:
@@ -101,7 +106,7 @@ resources:
       ports:
       - '4789'
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceTags:
     - {{ properties['prefix'] }}-master
     - {{ properties['prefix'] }}-node
@@ -118,7 +123,7 @@ resources:
       ports:
       - '10250'
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceTags:
     - {{ properties['prefix'] }}-master
     - {{ properties['prefix'] }}-infra-node
@@ -137,7 +142,7 @@ resources:
       ports:
       - '443'
     description: ''
-    network: $(ref.{{ properties['prefix'] }}-network.selfLink)
+    network: {{ network }}
     sourceRanges:
     - 0.0.0.0/0
     targetTags:

--- a/reference-architecture/gcp/deployment-manager/tmp-instance-config.yaml.j2
+++ b/reference-architecture/gcp/deployment-manager/tmp-instance-config.yaml.j2
@@ -8,4 +8,6 @@ resources:
     zone: {{ gcloud_zone }}
     region: {{ gcloud_region }}
     gce_vpc_custom_subnet_cidr: {{ gce_vpc_custom_subnet_cidr }}
+    gce_custom_vpc_network: {{ gce_custom_vpc_network }}
+    gce_custom_vpc_subnet: {{ gce_custom_vpc_subnet }}
     source_family: {{ 'projects/' + gcloud_project + '/global/images/family/rhel-guest-clean' if openshift_deployment_type == 'openshift-enterprise' else 'projects/centos-cloud/global/images/family/centos-7' }}

--- a/reference-architecture/gcp/deployment-manager/tmp-instance.jinja
+++ b/reference-architecture/gcp/deployment-manager/tmp-instance.jinja
@@ -1,3 +1,12 @@
+{% if properties['gce_custom_vpc_network'] %}
+{% set network = properties['gce_custom_vpc_network'] %}
+{% set subnet = properties['gce_custom_vpc_subnet'] %}
+{% else %}
+{% set network = properties['prefix'] + '-network' %}
+{% if properties['gce_vpc_custom_subnet_cidr'] %}
+{% set subnet = properties['prefix'] + '-' + properties['region'] + '-subnet' %}
+{% endif %}
+{% endif %}
 resources:
 - name: {{ properties['prefix'] }}-tmp-instance
   properties:
@@ -20,9 +29,9 @@ resources:
       - name: external-nat
         type: ONE_TO_ONE_NAT
       name: nic0
-      network: projects/{{env['project']}}/global/networks/{{ properties['prefix'] }}-network
-      {% if properties['gce_vpc_custom_subnet_cidr'] %}
-      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ properties['prefix'] }}-{{ properties['region'] }}-subnet
+      network: projects/{{env['project']}}/global/networks/{{ network }}
+      {% if subnet %}
+      subnetwork: projects/{{env['project']}}/regions/{{ properties['region'] }}/subnetworks/{{ subnet }}
       {% endif %}
     scheduling:
       automaticRestart: true


### PR DESCRIPTION
#### What does this PR do?
The reference architecture scripts for GCP are currently taking care of creating
a dedicated VPC and subnet for hosting the created OpenShift cluster.

There are some use cases where one may want to have the scripts attach the VM
to a pre-existing VPC and subnet:
— create an OpenShift cluster on a shared VPC defined in a distinct GCE project;
— create an OpenShift cluster on VPC/subnet previously connected via VPN to a
  remote network.

This change adds the possibility to make the GCP reference architecture scripts
attach the instances to a pre-existing VPC/subnet rather than creating a new one.

#### How should this be manually tested?
It can be tested by trying to create a cluster with the classical script:
```
ocp-on-gcp.sh
```
with a `config.yaml` file which contains,
* either empty values for the VPC/subnet to attach to:
  ```
  # Custom VPC
  # If default empty value is left, a dedicated VPC will be created.
  # If a VPC is specified, the VMs will be attached to that pre-existing VPC.
  gce_custom_vpc_network: ''
  gce_custom_vpc_subnet: ''
  ```
  in which case, `ocp-on-gcp.sh` must create a new dedicated VPC/subnets like it used to before this change;
* or names of pre-existing VPC/subnet to attach to:
  ```
  gce_custom_vpc_network: 'my-vpc-that-i-created-manually'
  gce_custom_vpc_subnet: 'my-subnet-that-i-created-manually'
  ```
  in which case, `ocp-on-gcp.sh` must attach the created instances to this VPC/subnet.

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @tomassedovic PTAL
