### PR TITLE
Rhv ocp3.7

### DIFF
--- a/reference-architecture/rhv-ansible/ocp-vars.yaml
+++ b/reference-architecture/rhv-ansible/ocp-vars.yaml
@@ -62,7 +62,7 @@ root_ssh_key:
 ### Openshift variables
 ## Choices of deployment type: openshift-enterprise, origin
 deployment_type: openshift-enterprise
-openshift_vers: v3_6
+openshift_vers: v3_7
 containerized: false
 console_port: 8443
 

--- a/reference-architecture/rhv-ansible/playbooks/openshift-install.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/openshift-install.yaml
@@ -49,6 +49,7 @@
     osm_use_cockpit: false
     osm_default_node_selector: "role=app"
     osm_default_subdomain: "{{ wildcard_zone }}"
+    openshift_deployment_type: "{{ deployment_type }}"
     openshift_hosted_registry_replicas: 1
     openshift_hosted_registry_storage_access_modes: ['ReadWriteMany']
     openshift_hosted_registry_storage_volume_size: 30Gi
@@ -69,6 +70,15 @@
         - "role={{ openshift_node_labels.role }}"
     openshift_registry_selector: "role=infra"
     openshift_router_selector: "role=infra"
+    openshift_metrics_hawkular_nodeselector: "role=infra"
+    openshift_metrics_cassandra_nodeselector: "role=infra"
+    openshift_metrics_heapster_nodeselector: "role=infra"
+    openshift_logging_es_nodeselector: "role=infra"
+    openshift_logging_kibana_nodeselector: "role=infra"
+    openshift_logging_curator_nodeselector: "role=infra"
+    #template_service_broker_selector: {'role': 'infra'}
+    #openshift_template_service_broker_namespaces: ['openshift', 'testproject']
+    openshift_enable_service_catalog: false
     # Load balancer config
     openshift_loadbalancer_additional_frontends:
       - name: apps-http

--- a/reference-architecture/rhv-ansible/playbooks/output-dns.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/output-dns.yaml
@@ -32,7 +32,7 @@
     - name: Create NSUPDATE reverse pointer entries
       lineinfile:
         path: ../inventory.nsupdate
-        line: "update add {{ '.'.join(hostvars[item]['devices']['eth0'].0.split('.')[::-1]) }}.in-addr.arpa 86400 PTR  {{ item }}.{{public_hosted_zone}}"
+        line: "update add {{ '.'.join(hostvars[item]['devices']['eth0'].0.split('.')[::-1]) }}.in-addr.arpa 86400 PTR  {{ item }}"
         state: present
       with_items:
         - "{{ groups['tag_openshift_master'] }}"
@@ -63,7 +63,7 @@
     - name: Create NSUPDATE host A entries
       lineinfile:
         path: ../inventory.nsupdate
-        line: "update add {{ item }}.{{public_hosted_zone}} 86400 A {{hostvars[item]['devices']['eth0'].0}}"
+        line: "update add {{ item }} 86400 A {{hostvars[item]['devices']['eth0'].0}}"
         state: present
       with_items:
         - "{{ groups['tag_openshift_master'] }}"
@@ -81,12 +81,12 @@
     - name: Create HOSTS public hostname
       lineinfile:
         path: ../inventory.hosts
-        line: "{{lb_ip}} {{lb_host}}.{{public_hosted_zone}} {{lb_host}} {{openshift_master_cluster_public_hostname}}"
+        line: "{{lb_ip}} {{lb_host}} {{openshift_master_cluster_public_hostname}}"
         state: present
     - name: Create HOSTS node entries
       lineinfile:
         path: ../inventory.hosts
-        line: "{{hostvars[item]['devices']['eth0'].0}} {{ item }}.{{ public_hosted_zone }} {{ item }}"
+        line: "{{hostvars[item]['devices']['eth0'].0}} {{ item }}"
       with_items:
         - "{{ groups['tag_openshift_master'] }}"
         - "{{ groups['tag_openshift_infra'] }}"

--- a/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
@@ -2,7 +2,7 @@
 ###########################
 # Common
 ###########################
-compatibility_version: 4.1
+compatibility_version: 4.2
 
 # Data center
 data_center_name: Default
@@ -56,12 +56,14 @@ vms:
     cloud_init:
       host_name: "openshift-node-0.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
   - name: openshift-node-1
     tag: openshift_node
     profile: "{{ node_vm }}"
     cloud_init:
       host_name: "openshift-node-1.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
 
   # Infra VMs
   - name: openshift-infra-0
@@ -70,12 +72,14 @@ vms:
     cloud_init:
       host_name: "openshift-infra-0.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
   - name: openshift-infra-1
     tag: openshift_infra
     profile: "{{ node_vm }}"
     cloud_init:
       host_name: "openshift-infra-1.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
 
   # Master VMs
   - name: openshift-master-0
@@ -84,18 +88,21 @@ vms:
     cloud_init:
       host_name: "openshift-master-0.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
   - name: openshift-master-1
     tag: openshift_master
     profile: "{{ master_vm }}"
     cloud_init:
       host_name: "openshift-master-1.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
   - name: openshift-master-2
     tag: openshift_master
     profile: "{{ master_vm }}"
     cloud_init:
       host_name: "openshift-master-2.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
 
   # Load balancer
   - name: openshift-lb
@@ -104,6 +111,7 @@ vms:
     cloud_init:
       host_name: "openshift-lb.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
+      root_password: "{{ root_password | default(omit) }}"
 
 affinity_groups:
   - name: masters_ag

--- a/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/vars/ovirt-infra-vars.yaml
@@ -50,14 +50,14 @@ node_vm:
 
 vms:
   # Node VMs
-  - name: openshift-node-0
+  - name: "openshift-node-0.{{ public_hosted_zone }}"
     tag: openshift_node
     profile: "{{ node_vm }}"
     cloud_init:
       host_name: "openshift-node-0.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
       root_password: "{{ root_password | default(omit) }}"
-  - name: openshift-node-1
+  - name: "openshift-node-1.{{ public_hosted_zone }}"
     tag: openshift_node
     profile: "{{ node_vm }}"
     cloud_init:
@@ -66,14 +66,14 @@ vms:
       root_password: "{{ root_password | default(omit) }}"
 
   # Infra VMs
-  - name: openshift-infra-0
+  - name: "openshift-infra-0.{{ public_hosted_zone }}"
     tag: openshift_infra
     profile: "{{ node_vm }}"
     cloud_init:
       host_name: "openshift-infra-0.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
       root_password: "{{ root_password | default(omit) }}"
-  - name: openshift-infra-1
+  - name: "openshift-infra-1.{{ public_hosted_zone }}"
     tag: openshift_infra
     profile: "{{ node_vm }}"
     cloud_init:
@@ -82,21 +82,21 @@ vms:
       root_password: "{{ root_password | default(omit) }}"
 
   # Master VMs
-  - name: openshift-master-0
+  - name: "openshift-master-0.{{ public_hosted_zone }}"
     profile: "{{ master_vm }}"
     tag: openshift_master
     cloud_init:
       host_name: "openshift-master-0.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
       root_password: "{{ root_password | default(omit) }}"
-  - name: openshift-master-1
+  - name: "openshift-master-1.{{ public_hosted_zone }}"
     tag: openshift_master
     profile: "{{ master_vm }}"
     cloud_init:
       host_name: "openshift-master-1.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"
       root_password: "{{ root_password | default(omit) }}"
-  - name: openshift-master-2
+  - name: "openshift-master-2.{{ public_hosted_zone }}"
     tag: openshift_master
     profile: "{{ master_vm }}"
     cloud_init:
@@ -105,7 +105,7 @@ vms:
       root_password: "{{ root_password | default(omit) }}"
 
   # Load balancer
-  - name: openshift-lb
+  - name: "openshift-lb.{{ public_hosted_zone }}"
     tag: openshift_lb
     profile: "{{ node_vm }}"
     cloud_init:
@@ -119,18 +119,18 @@ affinity_groups:
     vm_enforcing: false
     vm_rule: negative
     vms:
-      - openshift-master-0
-      - openshift-master-1
-      - openshift-master-2
+      - "openshift-master-0.{{ public_hosted_zone }}"
+      - "openshift-master-1.{{ public_hosted_zone }}"
+      - "openshift-master-2.{{ public_hosted_zone }}"
     wait: true
   - name: infra_ag
     cluster: "{{ rhv_cluster }}"
     vm_enforcing: false
     vm_rule: negative
     vms:
-      - openshift-infra-0
-      - openshift-infra-1
-      - openshift-lb
+      - "openshift-infra-0.{{ public_hosted_zone }}"
+      - "openshift-infra-1.{{ public_hosted_zone }}"
+      - "openshift-lb.{{ public_hosted_zone }}"
     wait: true
 
   - name: app_ag
@@ -138,6 +138,6 @@ affinity_groups:
     vm_enforcing: false
     vm_rule: negative
     vms:
-      - openshift-node-0
-      - openshift-node-1
+      - "openshift-node-0.{{ public_hosted_zone }}"
+      - "openshift-node-1.{{ public_hosted_zone }}"
 ...


### PR DESCRIPTION
#### What does this PR do?
Changes to accommodate OpenShift 3.7
 - Disable installation of service catalog without storage provisioner
 - fix node naming to FQDN

#### How should this be manually tested?
Has been tested against rhel 7.4 and RHV 4.2 beta

#### Is there a relevant Issue open for this?
 - https://github.com/openshift/openshift-ansible-contrib/issues/930

#### Who would you like to review this?
cc: @cooktheryan @e-minguez PTAL
