### PR TITLE
Resolve add-node error on aws(#960)

### DIFF
--- a/reference-architecture/aws-ansible/playbooks/node-setup.yaml
+++ b/reference-architecture/aws-ansible/playbooks/node-setup.yaml
@@ -25,6 +25,7 @@
     openshift_hosted_router_replicas: 3
     openshift_hosted_registry_replicas: 3
     openshift_node_local_quota_per_fsgroup: 512Mi
+    openshift_clusterid: "{{ stack_name }}"
     openshift_master_cluster_method: native
     openshift_cloudprovider_kind: aws
     openshift_master_cluster_hostname: "internal-openshift-master.{{ public_hosted_zone }}"


### PR DESCRIPTION
Error "Ensure clusterid is set along with the cloudprovider" occur
in add-node playbook runtime.
It is because node-setup.yaml is called without "openshift_clusterid"
variable setting.
With openshift_clusterid variable, we can avoid this issue.

#### What does this PR do?
About An issue (https://github.com/openshift/openshift-ansible-contrib/issues/960)

#### How should this be manually tested?
I used python script ./add-node.py (with some options)

#### Is there a relevant Issue open for this?
https://github.com/openshift/openshift-ansible-contrib/issues/960

#### Who would you like to review this?
cc:  @dav1x
