### PR TITLE
Changed infranode/nodeVMSize to better fit HW prereqs.

### DIFF
--- a/reference-architecture/azure-ansible/3.7/azuredeploy.json
+++ b/reference-architecture/azure-ansible/3.7/azuredeploy.json
@@ -120,7 +120,7 @@
     },
     "infranodeVMSize" : {
       "type" : "string",
-      "defaultValue" : "Standard_DS4_v2",
+      "defaultValue" : "Standard_DS3_v2",
       "allowedValues" : [
         "Standard_A2",
         "Standard_A3",
@@ -191,7 +191,7 @@
     },
     "nodeVMSize" : {
       "type" : "string",
-      "defaultValue" : "Standard_DS4_v2",
+      "defaultValue" : "Standard_DS3_v2",
       "allowedValues" : [
         "Standard_A2",
         "Standard_A3",


### PR DESCRIPTION
DS4_v2 is overkill for infra/nodes and double the price of DS3_v2 which is above required minimums for infra/nodes. DS4_v4 is only the Azure minimum for the master HW prereq.

#### What does this PR do?
Align our hardware minimal prerequisites with Azure VM sizes. 

#### How should this be manually tested?
Deploy cluster with default Azure VM size. Observe DS3_v2 size of infra/node VMs.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @tomassedovic PTAL
