### PR TITLE
Check for the existence of atomic files before copy.

### DIFF
--- a/reference-architecture/day2ops/scripts/backup_master_node.sh
+++ b/reference-architecture/day2ops/scripts/backup_master_node.sh
@@ -18,7 +18,9 @@ ocpfiles(){
   mkdir -p ${BACKUPLOCATION}/etc/sysconfig
   echo "Exporting OCP related files to ${BACKUPLOCATION}"
   cp -aR /etc/origin ${BACKUPLOCATION}/etc
-  cp -aR /etc/sysconfig/atomic-* ${BACKUPLOCATION}/etc/sysconfig
+  if ls /etc/sysconfig/atomic-* 1> /dev/null 2>&1; then
+    cp -aR /etc/sysconfig/atomic-* ${BACKUPLOCATION}/etc/sysconfig
+  fi
 }
 
 otherfiles(){


### PR DESCRIPTION
 When these directories aren't present an error is generated:
 ```
   Exporting OCP related files to ./backup
    cp: cannot stat ‘/etc/sysconfig/atomic-*’: No such file or directory
 
```

Added logic to check for the existence of /etc/sysconfig/atomic-* before invoking the cp.  I only manually tested on an existing server that does not have the /etc/sysconfig/atomic- files.  I don't have access an atomic based install.