### PR TITLE
Few fixes to allow installation of OCP 3.9 on oVirt 4.2

### DIFF
--- a/reference-architecture/rhv-ansible/example/ocp-vars.yaml.cen39
+++ b/reference-architecture/rhv-ansible/example/ocp-vars.yaml.cen39
@@ -11,7 +11,7 @@ engine_cafile: ../ca.pem
 ##############################################################################
 ### Red Hat Virtualization VM Image
 ## For CentOS 7:
-qcow_url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+qcow_url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2c
 ## For RHEL: Find KVM Guest Image in Downloads -> RHEL on https://access.redhat.com/ and use before the link expires:
 #qcow_url:https://access.cdn.redhat.com//content/origin/files/<omitted>/rhel-server-7.4-x86_64-kvm.qcow2?_auth_=<omitted>
 ## Alternatively, download the above KVM image, and re-host it on a local satellite:

--- a/reference-architecture/rhv-ansible/example/vars/ovirt-cen39-vars.yaml
+++ b/reference-architecture/rhv-ansible/example/vars/ovirt-cen39-vars.yaml
@@ -16,6 +16,7 @@ template_memory: 8GiB
 template_cpu: 2
 template_disk_storage: "{{ rhv_data_storage }}"
 template_disk_size: 60GiB
+template_operating_system: rhel_7x64
 template_nics:
   - name: nic1
     profile_name: ovirtmgmt
@@ -24,8 +25,7 @@ template_nics:
 ##########################
 # Other top scope vars
 ##########################
-# Centos does not have guest agent...
-#wait_for_ip: false
+wait_for_ip: true
 # See if anything goes wrong...
 debug_vm_create: true
 
@@ -34,6 +34,7 @@ master_vm:
   template: "{{ template_name }}"
   memory: 16GiB
   cores: 2
+  state: running
   high_availability: true
   disks:
     - size: 100GiB
@@ -46,6 +47,7 @@ node_vm:
   template: "{{ template_name }}"
   memory: 8GiB
   cores: 2
+  state: running
   disks:
     - size: 100GiB
       storage_domain: "{{ rhv_data_storage }}"
@@ -64,7 +66,8 @@ install_guest_agent_script: |
       enabled: true
       gpgcheck: false
   packages:
-    - ovirt-guest-agent
+    - ovirt-guest-agent-common
+    - python-ipaddress
   runcmd:
     - systemctl enable ovirt-guest-agent
     - systemctl start ovirt-guest-agent
@@ -72,8 +75,8 @@ install_guest_agent_script: |
 vms:
   # Master VMs
   - name: "openshift-master-0.{{ public_hosted_zone }}"
-    profile: "{{ master_vm }}"
     tag: openshift_master
+    profile: "{{ master_vm }}"
     cloud_init:
       host_name: "openshift-master-0.{{ public_hosted_zone }}"
       authorized_ssh_keys: "{{ root_ssh_key }}"

--- a/reference-architecture/rhv-ansible/playbooks/output-dns.yaml
+++ b/reference-architecture/rhv-ansible/playbooks/output-dns.yaml
@@ -39,6 +39,7 @@
         - "{{ groups['tag_openshift_infra'] }}"
         - "{{ groups['tag_openshift_node'] }}"
         - "{{ groups['tag_openshift_lb'] }}"
+      when: nsupdate_server is defined
     - name: Append show/send lines
       lineinfile:
         path: ../inventory.nsupdate
@@ -50,16 +51,19 @@
         path: ../inventory.nsupdate
         line: "zone {{public_hosted_zone}}"
         state: present
+      when: nsupdate_server is defined
     - name: Create NSUPDATE wildcard A entry
       lineinfile:
         path: ../inventory.nsupdate
         line: "update add *.{{app_dns_prefix}}.{{public_hosted_zone}} 86400 A {{lb_ip}}"
         state: present
+      when: nsupdate_server is defined
     - name: Create NSUPDATE public hostname entry
       lineinfile:
         path: ../inventory.nsupdate
         line: "update add {{openshift_master_cluster_public_hostname}} 86400 A {{lb_ip}}"
         state: present
+      when: nsupdate_server is defined
     - name: Create NSUPDATE host A entries
       lineinfile:
         path: ../inventory.nsupdate
@@ -70,6 +74,7 @@
         - "{{ groups['tag_openshift_infra'] }}"
         - "{{ groups['tag_openshift_node'] }}"
         - "{{ groups['tag_openshift_lb'] }}"
+      when: nsupdate_server is defined
     - name: Append show/send lines
       lineinfile:
         path: ../inventory.nsupdate


### PR DESCRIPTION
1. Ensure python-ipaddress is installed on CentOS images.
2. Fix case when nsupdate is not needed.
3. Wait for VMs to be up and running (now that CentOS has the
ovirt-guest-agent installed.
4. It's installed using ovirt-guest-agent-common package.

#### What does this PR do?
Brief explanation of the code or documentation change you've made

#### How should this be manually tested?
Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @tomassedovic PTAL
