### PR TITLE
Fixes/azure set subscription

### DIFF
--- a/reference-architecture/azure-ansible/3.7/allinone.sh
+++ b/reference-architecture/azure-ansible/3.7/allinone.sh
@@ -777,6 +777,8 @@ metadata:
     volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/azure-disk
 provisioner: kubernetes.io/azure-disk
 parameters:
+  #added 'kind: dedicated' as workaround of bug https://bugzilla.redhat.com/show_bug.cgi?id=1552384
+  kind: dedicated
   storageAccount: sapv${RESOURCEGROUP}
   location: ${LOCATION}
 EOF

--- a/reference-architecture/azure-ansible/3.7/allinone.sh
+++ b/reference-architecture/azure-ansible/3.7/allinone.sh
@@ -757,6 +757,7 @@ export AAD_CLIENT_ID=$(< ~/.azuresettings/aad_client_id)
 export AAD_CLIENT_SECRET=$(< ~/.azuresettings/aad_client_secret)
 export RESOURCEGROUP=$(< ~/.azuresettings/resource_group)
 azure login --service-principal --tenant ${TENANT}  -u ${AAD_CLIENT_ID} -p ${AAD_CLIENT_SECRET}
+azure account set ${SUBSCRIPTIONID}
 azure storage account connectionstring show ${1} --resource-group ${RESOURCEGROUP}  > ~/.azuresettings/$1/connection.out
 sed -n '/connectionstring:/{p}' < ~/.azuresettings/${1}/connection.out > ~/.azuresettings/${1}/dataline.out
 export DATALINE=$(< ~/.azuresettings/${1}/dataline.out)
@@ -884,6 +885,7 @@ export AAD_CLIENT_ID=$(< ~/.azuresettings/aad_client_id)
 export AAD_CLIENT_SECRET=$(< ~/.azuresettings/aad_client_secret)
 export RESOURCEGROUP=$(< ~/.azuresettings/resource_group)
 azure login --service-principal --tenant ${TENANT}  -u ${AAD_CLIENT_ID} -p ${AAD_CLIENT_SECRET}
+azure account set ${SUBSCRIPTIONID}
 azure storage account connectionstring show ${1} --resource-group ${RESOURCEGROUP} > ~/.azuresettings/$1/connection.out
 sed -n '/connectionstring:/{p}' < ~/.azuresettings/${1}/connection.out > ~/.azuresettings/${1}/dataline.out
 export DATALINE=$(< ~/.azuresettings/${1}/dataline.out)


### PR DESCRIPTION
#### What does this PR do?
- After the azure login command, set the right account subscription for issue [https://github.com/openshift/openshift-ansible-contrib/issues/1002](https://github.com/openshift/openshift-ansible-contrib/issues/1002)

- In `/home/${AUSERNAME}/scgeneric.yml` added `kind: dedicated` as workaround for [https://bugzilla.redhat.com/show_bug.cgi?id=1552384](https://bugzilla.redhat.com/show_bug.cgi?id=1552384)

#### How should this be manually tested?
Use azure credentials that can access 2 azure subscriptions and try the deployment both using the azure web console and the `allinone.json` template

#### Is there a relevant Issue open for this?
[https://github.com/openshift/openshift-ansible-contrib/issues/1002](https://github.com/openshift/openshift-ansible-contrib/issues/1002)

#### Who would you like to review this?
cc: @tomassedovic PTAL
