### PR TITLE
fix symlinks

### DIFF
--- a/playbooks/library/rpm_q.py
+++ b/playbooks/library/rpm_q.py
@@ -1,1 +1,1 @@
-/usr/share/ansible/openshift-ansible/library/rpm_q.py
+/usr/share/ansible/openshift-ansible/roles/lib_utils/library/rpm_q.py

--- a/reference-architecture/aws-ansible/playbooks/library/rpm_q.py
+++ b/reference-architecture/aws-ansible/playbooks/library/rpm_q.py
@@ -1,1 +1,1 @@
-/usr/share/ansible/openshift-ansible/library/rpm_q.py
+/usr/share/ansible/openshift-ansible/roles/lib_utils/library/rpm_q.py

--- a/reference-architecture/vmware-ansible/playbooks/library/rpm_q.py
+++ b/reference-architecture/vmware-ansible/playbooks/library/rpm_q.py
@@ -1,1 +1,1 @@
-/usr/share/ansible/openshift-ansible/library/rpm_q.py
+/usr/share/ansible/openshift-ansible/roles/lib_utils/library/rpm_q.py


### PR DESCRIPTION
https://github.com/openshift/openshift-ansible/pull/6469 relocated rpm_q.py to a
different directory.

#### What does this PR do?

Fixes symlinks

#### How should this be manually tested?

Observe that if using openshift-ansible-contrib and OCP 3.9, the destinations for the symlinks doesn't work.

#### Is there a relevant Issue open for this?

No.

#### Who would you like to review this?
cc: @tomassedovic PTAL
