### PR TITLE
Ref Arch 3.9 fixes

### DIFF
--- a/reference-architecture/3.9/playbooks/lookup_plugins/ec2_zones_by_region.py
+++ b/reference-architecture/3.9/playbooks/lookup_plugins/ec2_zones_by_region.py
@@ -25,14 +25,14 @@ class LookupModule(LookupBase):
     def run(self, args, inject=None, **kwargs):
         try:
             for a in list(args):
-                if 'region' in a:
-                    region = a['region']
+                if 'aws_region' in a:
+                    aws_region = a['aws_region']
         except Exception as e:
             raise errors.AnsibleError("%s" % (e))
 
         try:
             zones = []
-            response = boto3.client('ec2', region).describe_availability_zones()
+            response = boto3.client('ec2', aws_region).describe_availability_zones()
             for k in response['AvailabilityZones']:
                 zones.append(k['ZoneName'])
             return(zones)

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Create EC2 bastion instance
+- name: Create EC2 instance ( Bastion )
   ec2:
     assign_public_ip: yes
     count_tag:
@@ -17,7 +17,7 @@
       "kubernetes.io/cluster/{{ clusterid }}": "{{ clusterid }}"
     key_name: "{{ clusterid }}"
     monitoring: no
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     termination_protection: no
     user_data: "{{ lookup('file', ( playbook_dir + '/roles/aws/files/ec2_userdata_bastion.sh') ) }}"
     volumes:
@@ -25,7 +25,7 @@
         volume_type: gp2
         volume_size: 25
         delete_on_termination: true
-    vpc_subnet_id: "{{ subnet_routing.results.0.subnet.id }}"
+    vpc_subnet_id: "{{ subnet_public.results.0.subnet.id }}"
     wait: yes
   retries: 3
   delay: 3
@@ -43,23 +43,22 @@
     - tagss: "Name={{ item.id }}-rootvol, clusterid={{ clusterid }}, "
   with_items: "{{ ec2bastion.tagged_instances }}"
 
-- name: Create EIP instance for EC2 / bastion
+- name: Create EIP instance for EC2 / Bastion
   ec2_eip:
     device_id: "{{ ec2bastion.tagged_instances.0.id }}"
     in_vpc: yes
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
   retries: 3
   register: eipbastion
 
-- name: Create EC2 master instances
+- name: Create EC2 instances ( Master )
   ec2:
     assign_public_ip: no
     count_tag:
       Name: "{{ item.name }}"
     exact_count: 1
     group: [
-      "SSH",
       "master",
       "node"
     ]
@@ -69,7 +68,7 @@
       Name: "{{ item.name }}"
     key_name: "{{ clusterid }}"
     monitoring: no
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     termination_protection: no
     user_data: "{{ lookup('file', ( playbook_dir + '/roles/aws/files/ec2_userdata_master.sh') ) }}"
     volumes:
@@ -90,11 +89,11 @@
     wait: yes
   with_items:
     - name: "master1"
-      subnet: "{{ subnet_internal.results.0.subnet.id }}"
+      subnet: "{{ subnet_private.results.0.subnet.id }}"
     - name: "master2"
-      subnet: "{{ subnet_internal.results.1.subnet.id }}"
+      subnet: "{{ subnet_private.results.1.subnet.id }}"
     - name: "master3"
-      subnet: "{{ subnet_internal.results.2.subnet.id }}"
+      subnet: "{{ subnet_private.results.2.subnet.id }}"
   retries: 3
   delay: 3
   register: ec2master
@@ -129,14 +128,13 @@
     - tagss: "Name={{ item.tagged_instances[0].id }}-xvdd, clusterid={{ clusterid }}, "
   with_items: "{{ ec2master.results }}"
 
-- name: Create EC2 infra instances
+- name: Create EC2 instances ( Infrastructure )
   ec2:
     assign_public_ip: no
     count_tag:
       Name: "{{ item.name }}"
     exact_count: 1
     group: [
-      "SSH",
       "infra",
       "node"
     ]
@@ -146,7 +144,7 @@
       Name: "{{ item.name }}"
     key_name: "{{ clusterid }}"
     monitoring: no
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     termination_protection: no
     user_data: "{{ lookup('file', ( playbook_dir + '/roles/aws/files/ec2_userdata_node.sh') ) }}"
     volumes:
@@ -160,11 +158,11 @@
     wait: yes
   with_items:
     - name: "infra1"
-      subnet: "{{ subnet_internal.results.0.subnet.id }}"
+      subnet: "{{ subnet_private.results.0.subnet.id }}"
     - name: "infra2"
-      subnet: "{{ subnet_internal.results.1.subnet.id }}"
+      subnet: "{{ subnet_private.results.1.subnet.id }}"
     - name: "infra3"
-      subnet: "{{ subnet_internal.results.2.subnet.id }}"
+      subnet: "{{ subnet_private.results.2.subnet.id }}"
   retries: 3
   delay: 3
   register: ec2infra
@@ -187,14 +185,13 @@
     - tagss: "Name={{ item.tagged_instances[0].id }}-xvdb, clusterid={{ clusterid }}, "
   with_items: "{{ ec2infra.results }}"
 
-- name: Create EC2 node instances
+- name: Create EC2 instances ( App node )
   ec2:
     assign_public_ip: no
     count_tag:
       Name: "{{ item.name }}"
     exact_count: 1
     group: [
-      "SSH",
       "node"
     ]
     instance_type: "{{ ec2_type_node }}"
@@ -203,7 +200,7 @@
       Name: "{{ item.name }}"
     key_name: "{{ clusterid }}"
     monitoring: no
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     termination_protection: no
     user_data: "{{ lookup('file', ( playbook_dir + '/roles/aws/files/ec2_userdata_node.sh') ) }}"
     volumes:
@@ -220,11 +217,11 @@
     wait: yes
   with_items:
     - name: "node1"
-      subnet: "{{ subnet_internal.results.0.subnet.id }}"
+      subnet: "{{ subnet_private.results.0.subnet.id }}"
     - name: "node2"
-      subnet: "{{ subnet_internal.results.1.subnet.id }}"
+      subnet: "{{ subnet_private.results.1.subnet.id }}"
     - name: "node3"
-      subnet: "{{ subnet_internal.results.2.subnet.id }}"
+      subnet: "{{ subnet_private.results.2.subnet.id }}"
   retries: 3
   delay: 3
   register: ec2node

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2_cns.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2_cns.yaml
@@ -6,7 +6,6 @@
       Name: "{{ item.name }}"
     exact_count: 1
     group: [
-      "SSH",
       "cns",
       "node"
     ]
@@ -16,7 +15,7 @@
       Name: "{{ item.name }}"
     key_name: "{{ clusterid }}"
     monitoring: no
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     termination_protection: no
     user_data: "{{ lookup('file', ( playbook_dir + '/roles/aws/files/ec2_userdata_node.sh') ) }}"
     volumes:
@@ -37,11 +36,11 @@
     wait: yes
   with_items:
     - name: "cns1"
-      subnet: "{{ subnet_internal.results.0.subnet.id }}"
+      subnet: "{{ subnet_private.results.0.subnet.id }}"
     - name: "cns2"
-      subnet: "{{ subnet_internal.results.1.subnet.id }}"
+      subnet: "{{ subnet_private.results.1.subnet.id }}"
     - name: "cns3"
-      subnet: "{{ subnet_internal.results.2.subnet.id }}"
+      subnet: "{{ subnet_private.results.2.subnet.id }}"
   retries: 3
   delay: 3
   register: ec2cns

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2elb.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2elb.yaml
@@ -4,7 +4,7 @@
   ec2_elb:
     instance_id: "{{ item.tagged_instances[0].id }}"
     ec2_elbs: "{{ elbextmaster.elb.name }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
   with_items:
     - "{{ ec2master.results }}"
@@ -16,7 +16,7 @@
   ec2_elb:
     instance_id: "{{ item.tagged_instances[0].id }}"
     ec2_elbs: "{{ elbintmaster.elb.name }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
   with_items:
     - "{{ ec2master.results }}"
@@ -28,7 +28,7 @@
   ec2_elb:
     instance_id: "{{ item.tagged_instances[0].id }}"
     ec2_elbs: "{{ elbextinfra.elb.name }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
   with_items:
     - "{{ ec2infra.results }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2keypair.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2keypair.yaml
@@ -3,6 +3,6 @@
   ec2_key:
     key_material: "{{ lookup('file', '~/.ssh/' + clusterid + '.pub') | expanduser }}"
     name: "{{ clusterid }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
   with_file: "~/.ssh/{{ clusterid }}.pub"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/elb.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/elb.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Create ELB ( master internet-facing endpoint )
+- name: Create ELB ( master internet-facing )
   ec2_elb_lb:
     cross_az_load_balancing: "yes"
     health_check:
@@ -16,23 +16,24 @@
         instance_protocol: tcp
         instance_port: 443
     name: "{{ clusterid }}-master-external"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     scheme: internet-facing
     security_group_names:
       - "master"
     state: present
     subnets:
-      - "{{ subnet_routing.results.0.subnet.id }}"
-      - "{{ subnet_routing.results.1.subnet.id }}"
-      - "{{ subnet_routing.results.2.subnet.id }}"
+      - "{{ subnet_public.results.0.subnet.id }}"
+      - "{{ subnet_public.results.1.subnet.id }}"
+      - "{{ subnet_public.results.2.subnet.id }}"
     tags:
       Name: "{{ clusterid }}-master-external"
       Clusterif: "{{ clusterid }}"
+    wait: true
   retries: 3
   delay: 3
   register: elbextmaster
 
-- name: Create ELB ( master internal endpoint )
+- name: Create ELB ( master internal )
   ec2_elb_lb:
     cross_az_load_balancing: "yes"
     health_check:
@@ -49,23 +50,24 @@
         instance_protocol: tcp
         instance_port: 443
     name: "{{ clusterid }}-master-internal"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     scheme: internal
     security_group_names:
       - "master"
     state: present
     subnets:
-      - "{{ subnet_internal.results.0.subnet.id }}"
-      - "{{ subnet_internal.results.1.subnet.id }}"
-      - "{{ subnet_internal.results.2.subnet.id }}"
+      - "{{ subnet_private.results.0.subnet.id }}"
+      - "{{ subnet_private.results.1.subnet.id }}"
+      - "{{ subnet_private.results.2.subnet.id }}"
     tags:
       Name: "{{ clusterid }}-master-internal"
       Clusterif: "{{ clusterid }}"
+    wait: true
   retries: 3
   delay: 3
   register: elbintmaster
 
-- name: Create ELB ( infra internet-facing endpoint )
+- name: Create ELB ( infra internet-facing )
   ec2_elb_lb:
     cross_az_load_balancing: "yes"
     health_check:
@@ -93,18 +95,19 @@
         instance_protocol: tcp
         instance_port: 9090
     name: "{{ clusterid }}-infra-external"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     scheme: internet-facing
     security_group_names:
       - "infra"
     state: present
     subnets:
-      - "{{ subnet_routing.results.0.subnet.id }}"
-      - "{{ subnet_routing.results.1.subnet.id }}"
-      - "{{ subnet_routing.results.2.subnet.id }}"
+      - "{{ subnet_public.results.0.subnet.id }}"
+      - "{{ subnet_public.results.1.subnet.id }}"
+      - "{{ subnet_public.results.2.subnet.id }}"
     tags:
       Name: "{{ clusterid }}-infra-external"
       Clusterid: "{{ clusterid }}"
+    wait: true
   retries: 3
   delay: 3
   register: elbextinfra

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/getcreds.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/getcreds.yaml
@@ -1,16 +1,18 @@
 ---
 - name: "Retrive credentials from env vars"
   ignore_errors: true
+  no_log: True
   set_fact:
     aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
     aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
-    region: "{{ lookup('env','AWS_REGION') }}"
 
 - name: "Retrive credentials from creds file"
+  ignore_errors: true
+  no_log: True
   set_fact:
-    aws_access_key: "{{ lookup('ini', 'aws_access_key_id section={{ credsprofile }} file=~/.aws/credentials') }}"
-    aws_secret_key: "{{ lookup('ini', 'aws_secret_access_key section={{ credsprofile }} file=~/.aws/credentials') }}"
-    region: "{{ lookup('ini', 'region section={{ credsprofile }} file=~/.aws/credentials') }}"
+    aws_access_key: "{{ lookup('ini', 'aws_access_key_id section={{ aws_cred_profile }} file=~/.aws/credentials') }}"
+    aws_secret_key: "{{ lookup('ini', 'aws_secret_access_key section={{ aws_cred_profile }} file=~/.aws/credentials') }}"
+  when: ( not aws_access_key ) and ( not aws_secret_key )
 
 - debug:
     msg:
@@ -29,4 +31,4 @@
     creds:
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      region: "{{ region }}"
+      aws_region: "{{ aws_region }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
@@ -1,11 +1,12 @@
 ---
 - name: Fetch Red Hat Cloud Access ami
-  shell: aws ec2 describe-images --owners 309956199498 | \
+  shell: aws ec2 describe-images \
+    --region "{{ aws_region }}" --owners 309956199498 | \
     jq -r '.Images[] | [.Name,.ImageId] | @csv' | \
     sed -e 's/\"//g' | \
     grep -v Beta | \
     grep -i Access2-GP2 | \
-    grep -i "{{ rhelrel }}" | \
+    grep -i "{{ rhel_release }}" | \
     sort | \
     tail -1
   args:

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/iam.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/iam.yaml
@@ -29,11 +29,10 @@
 - name: Create IAM policy for cloudprovider_kind
   iam_policy:
     iam_type: user
-    iam_name: "{{ cpkuser.user_meta.created_user.user_name }}"
+    iam_name: "{{ clusterid }}-admin"
     policy_name: "Admin"
     state: present
-    policy_json: "{{ lookup('template', playbook_dir + '/roles/aws/templates/iam_policy_cpkuser.json.j2', convert_data=False) | string }}"
-  when: cpkuser.changed
+    policy_json: "{{ lookup('template', playbook_dir + '/roles/aws/templates/iam_policy_cpkuser.json.j2') }}"
 
 - name: Create IAM user for Registry S3 storage
   iam:
@@ -61,8 +60,7 @@
 - name: Create IAM policy for OCP Docker Registry AWS S3 bucket
   iam_policy:
     iam_type: user
-    iam_name: "{{ s3user.user_meta.created_user.user_name }}"
+    iam_name: "{{ clusterid }}-registry"
     policy_name: "S3"
     state: present
-    policy_json: "{{ lookup('template', playbook_dir + '/roles/aws/templates/iam_policy_s3user.json.j2', convert_data=False) | string }}"
-  when: s3user.changed
+    policy_json: "{{ lookup('template', playbook_dir + '/roles/aws/templates/iam_policy_s3user.json.j2') }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/igw.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/igw.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create IGW
   ec2_vpc_igw:
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
     vpc_id: "{{ vpc.vpc.id }}"
   retries: 3

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/natgw.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/natgw.yaml
@@ -4,12 +4,12 @@
     if_exist_do_not_create: yes
     state: present
     subnet_id: "{{ item }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     wait: yes
   register: natgw
   retries: 3
   delay: 3
   with_items:
-    - "{{ subnet_routing.results.0.subnet.id }}"
-    - "{{ subnet_routing.results.1.subnet.id }}"
-    - "{{ subnet_routing.results.2.subnet.id }}"
+    - "{{ subnet_public.results.0.subnet.id }}"
+    - "{{ subnet_public.results.1.subnet.id }}"
+    - "{{ subnet_public.results.2.subnet.id }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/route53.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/route53.yaml
@@ -1,19 +1,19 @@
 ---
 - name: Create Route53 external zone
   route53_zone:
-    comment: "{{ clusterid }}.{{ domain }}"
+    comment: "{{ clusterid }}.{{ dns_domain }}"
     state: present
-    vpc_region: "{{ region }}"
-    zone: "{{ clusterid }}.{{ domain }}"
+    vpc_region: "{{ aws_region }}"
+    zone: "{{ clusterid }}.{{ dns_domain }}"
   register: r53zoneext
 
 - name: Create Route53 internal zone
   route53_zone:
-    comment: "{{ clusterid }}.{{ domain }}"
+    comment: "{{ clusterid }}.{{ dns_domain }}"
     state: present
     vpc_id: "{{ vpc.vpc.id }}"
-    vpc_region: "{{ region }}"
-    zone: "{{ clusterid }}.{{ domain }}"
+    vpc_region: "{{ aws_region }}"
+    zone: "{{ clusterid }}.{{ dns_domain }}"
   register: r53zoneint
 
 - name: 'Set fact: arg for lookup query'

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/route53records.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/route53records.yaml
@@ -42,7 +42,7 @@
     command: create
     overwrite: yes
     private_zone: no
-    record: "*.apps.{{ clusterid }}.{{ domain }}"
+    record: "*.apps.{{ clusterid }}.{{ dns_domain }}"
     type: CNAME
     ttl: 300
     value: "{{ elbextinfra.elb.dns_name }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/routetable.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/routetable.yaml
@@ -1,11 +1,11 @@
 ---
-- name: Create RouteTable (routing)
+- name: Create RouteTable ( Public )
   ec2_vpc_route_table:
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     subnets:
-      - "{{ subnet_routing.results.0.subnet.id }}"
-      - "{{ subnet_routing.results.1.subnet.id }}"
-      - "{{ subnet_routing.results.2.subnet.id }}"
+      - "{{ subnet_public.results.0.subnet.id }}"
+      - "{{ subnet_public.results.1.subnet.id }}"
+      - "{{ subnet_public.results.2.subnet.id }}"
     routes:
       - dest: 0.0.0.0/0
         gateway_id: "{{ igw.gateway_id }}"
@@ -14,11 +14,10 @@
     vpc_id: "{{ vpc.vpc.id }}"
   retries: 3
   delay: 3
-  register: rt
 
-- name: Create RouteTables (internal)
+- name: Create RouteTables ( Private )
   ec2_vpc_route_table:
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     subnets:
       - "{{ item.subnet }}"
     routes:
@@ -29,14 +28,13 @@
     vpc_id: "{{ vpc.vpc.id }}"
   retries: 3
   delay: 5
-  register: rt
   with_items:
     - az: "{{ vpc_subnet_azs.0 }}"
-      subnet: "{{ subnet_internal.results.0.subnet.id }}"
+      subnet: "{{ subnet_private.results.0.subnet.id }}"
       natgw: "{{ natgw.results.0.nat_gateway_id }}"
     - az: "{{ vpc_subnet_azs.1 }}"
-      subnet: "{{ subnet_internal.results.1.subnet.id }}"
+      subnet: "{{ subnet_private.results.1.subnet.id }}"
       natgw: "{{ natgw.results.1.nat_gateway_id }}"
     - az: "{{ vpc_subnet_azs.2 }}"
-      subnet: "{{ subnet_internal.results.2.subnet.id }}"
+      subnet: "{{ subnet_private.results.2.subnet.id }}"
       natgw: "{{ natgw.results.2.nat_gateway_id }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/s3.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/s3.yaml
@@ -3,7 +3,7 @@
   s3_bucket:
     name: "{{ clusterid }}-registry"
     policy: "{{ lookup('template', playbook_dir + '/roles/aws/templates/s3_bucket_policy_registry.json', convert_data=False) | string }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
     tags:
       Clusterid: "{{ clusterid }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygroup.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygroup.yaml
@@ -1,22 +1,12 @@
 ---
-- name: Create AWS SecurityGroup (SSH)
+- name: Create AWS SecurityGroup (Bastion)
   ec2_group:
-    name: "SSH"
-    description: "SSH"
+    name: "Bastion"
+    description: "Bastion"
     purge_rules: false
     purge_rules_egress: false
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     vpc_id: "{{ vpc.vpc.id }}"
-    rules:
-      - proto: icmp
-        from_port: 8
-        to_port: -1
-        cidr_ip: 0.0.0.0/0
-      - proto: tcp
-        from_port: "22"
-        to_port: "22"
-        cidr_ip: "0.0.0.0/0"
-  register: sshsg
 
 - name: "Create AWS SecurityGroups"
   ec2_group:
@@ -24,7 +14,7 @@
     description: "{{ item.name }}"
     purge_rules: false
     purge_rules_egress: false
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     vpc_id: "{{ vpc.vpc.id }}"
   register: sg
   with_items:

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygroup_cns.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygroup_cns.yaml
@@ -5,7 +5,7 @@
     description: "cns"
     purge_rules: false
     purge_rules_egress: false
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     vpc_id: "{{ vpc.vpc.id }}"
   register: sgcns
 
@@ -13,18 +13,34 @@
   ec2_group:
     name: "cns"
     description: "cns"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     vpc_id: "{{ vpc.vpc.id }}"
     rules:
       - proto: tcp
+        from_port: 111
+        to_port: 111
+        group_name: "cns"
+      - proto: tcp
         from_port: 2222
         to_port: 2222
+        group_name: "cns"
+      - proto: tcp
+        from_port: 3260
+        to_port: 3260
         group_name: "cns"
       - proto: tcp
         from_port: 24007
         to_port: 24008
         group_name: "cns"
       - proto: tcp
+        from_port: 24010
+        to_port: 24010
+        group_name: "cns"
+      - proto: tcp
         from_port: 49152
         to_port: 49664
+        group_name: "cns"
+      - proto: udp
+        from_port: 111
+        to_port: 111
         group_name: "cns"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygroup_rules.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygroup_rules.yaml
@@ -1,11 +1,29 @@
 ---
+- name: Create AWS SecurityGroup (SSH)
+  ec2_group:
+    name: "Bastion"
+    description: "Bastion"
+    purge_rules: false
+    purge_rules_egress: false
+    region: "{{ aws_region }}"
+    vpc_id: "{{ vpc.vpc.id }}"
+    rules:
+      - proto: icmp
+        from_port: 8
+        to_port: -1
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: "22"
+        to_port: "22"
+        cidr_ip: "0.0.0.0/0"
+
 - name: "Create AWS SecurityGroups Rules (Infra)"
   ec2_group:
     name: "infra"
     description: "infra"
     purge_rules: true
     purge_rules_egress: true
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     vpc_id: "{{ vpc.vpc.id }}"
     rules:
       - proto: tcp
@@ -31,7 +49,7 @@
     description: "master"
     purge_rules: true
     purge_rules_egress: true
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     vpc_id: "{{ vpc.vpc.id }}"
     rules:
       - proto: tcp
@@ -65,7 +83,7 @@
     description: "node"
     purge_rules: true
     purge_rules_egress: true
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     vpc_id: "{{ vpc.vpc.id }}"
     rules:
       - proto: icmp

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/sshkeys.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/sshkeys.yaml
@@ -13,7 +13,7 @@
   failed_when: "'r3dh@t' in sshkeys.state"
 
 - name: "Generate SSH key"
-  command: ssh-keygen -b 2048 -t rsa -f ~/.ssh/{{ clusterid }} -q -C user@"{{ domain }}" -N "{{ ssh_password }}" -q
+  command: ssh-keygen -b 2048 -t rsa -f ~/.ssh/{{ clusterid }} -q -C user@"{{ dns_domain }}" -N "{{ sshkey_password }}" -q
   args:
     creates: "~/.ssh/{{ clusterid }}"
   when: sshkeys.changed

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/subnet.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/subnet.yaml
@@ -1,38 +1,38 @@
 ---
-- name: Create AWS subnets (routing)
+- name: Create AWS subnets (public)
   ec2_vpc_subnet:
     az: "{{ item.az }}"
     cidr: "{{ item.cidr }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
     vpc_id: "{{ vpc.vpc.id }}"
     wait: False
   with_items:
-    - cidr: "{{ cidrsubnets_routing.0 }}"
+    - cidr: "{{ subnets_public_cidr.0 }}"
       az: "{{ vpc_subnet_azs.0 }}"
-    - cidr: "{{ cidrsubnets_routing.1 }}"
+    - cidr: "{{ subnets_public_cidr.1 }}"
       az: "{{ vpc_subnet_azs.1 }}"
-    - cidr: "{{ cidrsubnets_routing.2 }}"
+    - cidr: "{{ subnets_public_cidr.2 }}"
       az: "{{ vpc_subnet_azs.2 }}"
   retries: 3
   delay: 3
-  register: subnet_routing
+  register: subnet_public
 
-- name: Create AWS subnets (internal)
+- name: Create AWS subnets (private)
   ec2_vpc_subnet:
     az: "{{ item.az }}"
     cidr: "{{ item.cidr }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
     vpc_id: "{{ vpc.vpc.id }}"
     wait: False
   with_items:
-    - cidr: "{{ cidrsubnets.0 }}"
+    - cidr: "{{ subnets_private_cidr.0 }}"
       az: "{{ vpc_subnet_azs.0 }}"
-    - cidr: "{{ cidrsubnets.1 }}"
+    - cidr: "{{ subnets_private_cidr.1 }}"
       az: "{{ vpc_subnet_azs.1 }}"
-    - cidr: "{{ cidrsubnets.2 }}"
+    - cidr: "{{ subnets_private_cidr.2 }}"
       az: "{{ vpc_subnet_azs.2 }}"
   retries: 3
   delay: 3
-  register: subnet_internal
+  register: subnet_private

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/tag.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/tag.yaml
@@ -8,6 +8,6 @@
 - name: Create tag
   ec2_tag:
     resource: "{{ resource }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     state: present
     tags: "{{ tagss }}"

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/vpc.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/vpc.yaml
@@ -2,10 +2,10 @@
 - name: Create VPC
   ec2_vpc_net:
     state: present
-    cidr_block: "{{ cidrvpc }}"
+    cidr_block: "{{ vpc_cidr }}"
     dhcp_opts_id: "{{ vpcdhcpopts.dhcp_options_id }}"
     name: "{{ clusterid }}"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
   retries: 3
   delay: 5
   register: vpc

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/vpcdhcpopts.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/vpcdhcpopts.yaml
@@ -2,7 +2,7 @@
 - name: "Create VPC DHCP Options"
   ec2_vpc_dhcp_options:
     domain_name: "ec2.internal"
-    region: "{{ region }}"
+    region: "{{ aws_region }}"
     dns_servers:
       - AmazonProvidedDNS
     inherit_existing: False

--- a/reference-architecture/3.9/playbooks/roles/aws/templates/iam_policy_s3user.json.j2
+++ b/reference-architecture/3.9/playbooks/roles/aws/templates/iam_policy_s3user.json.j2
@@ -7,8 +7,10 @@
                 "s3:*"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:s3:::{{ clusterid }}-registry"
-            "Resource": "arn:aws:s3:::{{ clusterid }}-registry/*"
+            "Resource": [
+                "arn:aws:s3:::{{ clusterid }}-registry",
+                "arn:aws:s3:::{{ clusterid }}-registry/*"
+            ]
         }
     ]
 }

--- a/reference-architecture/3.9/playbooks/roles/aws/templates/ocpinstallerhostsgfs.j2
+++ b/reference-architecture/3.9/playbooks/roles/aws/templates/ocpinstallerhostsgfs.j2
@@ -1,3 +1,4 @@
+[glusterfs]
 {% for i in ec2cns.results %}
 {{ i.tagged_instances[0].private_dns_name }} glusterfs_devices='[ "/dev/nvme1n1" ]'
 {% endfor %}

--- a/reference-architecture/3.9/playbooks/roles/aws/templates/ocpinstallers3.j2
+++ b/reference-architecture/3.9/playbooks/roles/aws/templates/ocpinstallers3.j2
@@ -3,7 +3,7 @@ openshift_hosted_registry_storage_kind=object
 openshift_hosted_registry_storage_provider=s3
 {{ lookup('file', ( '~/.ssh/config-' + clusterid + '-s3user_access_key') ) | regex_replace(".* ANSIBLE MANAGED BLOCK .*", '') | trim }}
 openshift_hosted_registry_storage_s3_bucket={{ clusterid }}-registry
-openshift_hosted_registry_storage_s3_region={{ region }}
+openshift_hosted_registry_storage_s3_region={{ aws_region }}
 openshift_hosted_registry_storage_s3_chunksize=26214400
 openshift_hosted_registry_storage_s3_rootdirectory=/registry
 openshift_hosted_registry_pullthrough=true

--- a/reference-architecture/3.9/playbooks/roles/aws/templates/ocpinstallerurls.j2
+++ b/reference-architecture/3.9/playbooks/roles/aws/templates/ocpinstallerurls.j2
@@ -1,3 +1,3 @@
-openshift_master_default_subdomain=apps.{{ clusterid }}.{{ domain }}
-openshift_master_cluster_hostname=master.{{ clusterid }}.{{ domain }}
-openshift_master_cluster_public_hostname=master.{{ clusterid }}.{{ domain }}
+openshift_master_default_subdomain=apps.{{ clusterid }}.{{ dns_domain }}
+openshift_master_cluster_hostname=master.{{ clusterid }}.{{ dns_domain }}
+openshift_master_cluster_public_hostname=master.{{ clusterid }}.{{ dns_domain }}

--- a/reference-architecture/3.9/playbooks/roles/aws/templates/ssh_config.j2
+++ b/reference-architecture/3.9/playbooks/roles/aws/templates/ssh_config.j2
@@ -1,5 +1,5 @@
 Host bastion
-  HostName                 {{ ec2bastion.tagged_instances[0].public_dns_name }}
+  HostName                 {{ ec2bastion.public_ip }}
   User                     ec2-user
   StrictHostKeyChecking    no
   ProxyCommand             none
@@ -13,6 +13,13 @@ Host bastion
   IdentityFile             ~/.ssh/{{ clusterid }}
 
 Host *.compute-1.amazonaws.com
+  user                     ec2-user
+  StrictHostKeyChecking    no
+  CheckHostIP              no
+  IdentityFile             ~/.ssh/{{ clusterid }}
+
+Host *.compute.internal
+  ProxyCommand             ssh -W %h:%p bastion
   user                     ec2-user
   StrictHostKeyChecking    no
   CheckHostIP              no

--- a/reference-architecture/3.9/playbooks/vars/main.yaml
+++ b/reference-architecture/3.9/playbooks/vars/main.yaml
@@ -1,18 +1,21 @@
 ---
+aws_cred_profile: "default"
+
+# password for ssh key - ~/.ssh/{{ clusterid }}
+sshkey_password: 'abc123'
+
 clusterid: "refarch"
-domain: "example.com"
-region: "us-east-1"
-credsprofile: "default"
-ssh_password: 'abc123'
+dns_domain: "example.com"
+aws_region: "us-east-1"
 
-cidrvpc: "172.16.0.0/16"
+vpc_cidr: "172.16.0.0/16"
 
-cidrsubnets_routing:
+subnets_public_cidr:
   - 172.16.0.0/24
   - 172.16.1.0/24
   - 172.16.2.0/24
 
-cidrsubnets:
+subnets_private_cidr:
   - 172.16.16.0/20
   - 172.16.32.0/20
   - 172.16.48.0/20
@@ -23,4 +26,4 @@ ec2_type_infra: "m5.2xlarge"
 ec2_type_node: "m5.2xlarge"
 ec2_type_cns: "m5.2xlarge"
 
-rhelrel: "rhel-7.5"
+rhel_release: "rhel-7.5"


### PR DESCRIPTION
#### What does this PR do?
Fix getcreds
Fix to region var override
Fix to SecurityGroup race condition
Fix getting ami
Fix iam user policies
Align subnet names with previous RA
Fix missing gluster ports
Hide getcreds log
Add glusterfs section to hostscns
Add *.compute.internal to ssh config

#### How should this be manually tested?
See RHOCP 3.9 on AWS reference architecture

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
@cooktheryan 