### PR TITLE
Fix ssh config to readd proxy for non-us-east-1 instances

### DIFF
--- a/reference-architecture/3.9/playbooks/roles/aws/templates/ssh_config.j2
+++ b/reference-architecture/3.9/playbooks/roles/aws/templates/ssh_config.j2
@@ -13,6 +13,14 @@ Host bastion
   ServerAliveInterval      30
   IdentityFile             ~/.ssh/{{ clusterid }}.{{ dns_domain }}
 
+Host *.compute.internal
+  ProxyCommand             ssh -W %h:%p bastion
+  user                     ec2-user
+  StrictHostKeyChecking    no
+  CheckHostIP              no
+  ServerAliveInterval      30
+  IdentityFile             ~/.ssh/{{ clusterid }}.{{ dns_domain }}
+
 Host *.ec2.internal
   ProxyCommand             ssh -W %h:%p bastion
   user                     ec2-user

--- a/reference-architecture/3.9/playbooks/vars/main.yaml
+++ b/reference-architecture/3.9/playbooks/vars/main.yaml
@@ -1,7 +1,7 @@
 ---
 aws_cred_profile: "default"
 
-# password for ssh key - ~/.ssh/{{ clusterid }}
+# password for ssh key - ~/.ssh/{{ clusterid }}.{{ dns_domain }}
 sshkey_password: 'abc123'
 
 clusterid: "refarch"


### PR DESCRIPTION
#### What does this PR do?
Fix ssh config to readd proxy for non-us-east-1 instances

#### How should this be manually tested?
See RHOCP 3.9 on AWS reference architecture

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
@cooktheryan 