### PR TITLE
Updates for AWS ref arch

### DIFF
--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
@@ -26,7 +26,7 @@
       debug:
         msg: "{{ notice.split('\n') }}"
       when: ec2ami_unformatted.changed
-      failed_when: "'ami-' not in ec2ami.stdout"
+      failed_when: ( ec2ami.stdout == "" ) or ( "'ami-' not in ec2ami.stdout" )
 
     - name: 'Set fact: ec2ami'
       set_fact:

--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
@@ -2,6 +2,7 @@
 - block:
     - name: Fetch Red Hat Cloud Access ami
       shell: aws ec2 describe-images \
+        --ouput=json \
         --region "{{ aws_region }}" --owners 309956199498 | \
         jq -r '.Images[] | [.Name,.ImageId] | @csv' | \
         sed -e 's/\"//g' | \

--- a/reference-architecture/3.9/playbooks/roles/aws/templates/iam_policy_cpkuser.json.j2
+++ b/reference-architecture/3.9/playbooks/roles/aws/templates/iam_policy_cpkuser.json.j2
@@ -3,7 +3,7 @@
     "Statement": [
         {
             "Action": [
-                "ec2:DescribeVolumes",
+                "ec2:DescribeVolume*",
                 "ec2:CreateVolume",
                 "ec2:CreateTags",
                 "ec2:DescribeInstances",


### PR DESCRIPTION
#### What does this PR do?
Fixes a problem with the condition on the NOTICE! debug/fail task.  When an ami is not not specified in the vars file the Cloud Access ami search task is triggered.  When the ami search task can't find an ami the fail task "NOTICE!  Red Hat Cloud Access machine image not found" task is supposed to be triggered.  The NOTICE! task will fail instead of executing debug output then fail.

Force aws describe-images command to json to ensure jq can consume and process output.

Fix to IAM policy statement

#### How should this be manually tested?
See OCP 3.9 on AWS reference architecture.

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
@cooktheryan 
