### PR TITLE
Fix to force to aws describe-images command to json

### DIFF
--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/getec2ami.yaml
@@ -1,9 +1,11 @@
 ---
 - block:
     - name: Fetch Red Hat Cloud Access ami
-      shell: aws ec2 describe-images \
-        --ouput=json \
-        --region "{{ aws_region }}" --owners 309956199498 | \
+      shell: aws \
+        --output json \
+        ec2 describe-images \
+        --region "{{ aws_region }}" \
+        --owners 309956199498 | \
         jq -r '.Images[] | [.Name,.ImageId] | @csv' | \
         sed -e 's/\"//g' | \
         grep -v Beta | \


### PR DESCRIPTION
#### What does this PR do?
Fix to force to aws describe-images command to json 

#### How should this be manually tested?
See OCP on AWS 3.9 reference architecture

#### Is there a relevant Issue open for this?

#### Who would you like to review this?
@cooktheryan 
