### PR TITLE
Vagrant OpenShift 3.10 Adaption

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -144,12 +144,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     admin1.vm.hostname = "admin1.example.com"
     admin1.hostmanager.aliases = %w(admin1)
 
-    if deployment_type == 'openshift-enterprise'
-      config_playbook = "/usr/share/ansible/openshift-ansible/playbooks/byo/config.yml"
-    else
-      config_playbook = "/home/vagrant/openshift-ansible/playbooks/byo/config.yml"
-    end
-
     admin1.vm.synced_folder "..", "/home/vagrant/sync", type: sync_type
     admin1.vm.synced_folder ".vagrant", "/home/vagrant/.hidden", type: sync_type
 
@@ -160,12 +154,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         ansible_become: true,
         ansible_ssh_user: 'vagrant',
         deployment_type: deployment_type,
-        openshift_master_identity_providers: "[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]",
+        openshift_deployment_type: deployment_type,
+        openshift_clock_enabled: true,
+        os_firewall_use_firewalld: true,
+        openshift_master_identity_providers: "[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'file': '/etc/origin/master/htpasswd'}]",
         openshift_master_htpasswd_users: "{'admin': '$apr1$nWG7vwhy$jCMCBmBrW3MEYmCFCckYk1'}",
         openshift_master_default_subdomain: 'apps.example.com',
-        osm_default_node_selector: 'region=primary',
-        openshift_hosted_registry_selector: 'region=infra',
+        osm_default_node_selector: 'node-role.kubernetes.io/compute=true',
+        openshift_hosted_router_selector: 'node-role.kubernetes.io/master=true',
+        openshift_hosted_registry_selector: 'node-role.kubernetes.io/master=true',
         openshift_hosted_registry_replicas: 1,
+        openshift_enable_unsupported_configurations: true, # Needed for NFS registry. For some unknown reason.
         openshift_hosted_registry_storage_kind: 'nfs',
         openshift_hosted_registry_storage_access_modes: ['ReadWriteMany'],
         openshift_hosted_registry_storage_host: 'admin1.example.com',
@@ -185,39 +184,38 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible_host_vars = {
       master1:  {
         openshift_ip: '192.168.50.20',
-        openshift_node_labels: quote_labels(
-          region: 'infra',
-          zone: 'default',
-        ),
         openshift_schedulable: true,
         ansible_host: '192.168.50.20',
-        ansible_ssh_private_key_file: "/home/vagrant/.ssh/master1.key"
+        ansible_ssh_private_key_file: "/home/vagrant/.ssh/master1.key",
+        openshift_node_group_name: "node-config-master"
       },
       node1: {
         openshift_ip: '192.168.50.21',
-        openshift_node_labels: quote_labels(
-          region: 'primary',
-          zone: 'east',
-        ),
         openshift_schedulable: true,
         ansible_host: '192.168.50.21',
-        ansible_ssh_private_key_file: "/home/vagrant/.ssh/node1.key"
+        ansible_ssh_private_key_file: "/home/vagrant/.ssh/node1.key",
+        openshift_node_group_name: "node-config-compute"
       },
       node2: {
         openshift_ip: '192.168.50.22',
-        openshift_node_labels: quote_labels(
-          region: 'primary',
-          zone: 'west',
-        ),
         openshift_schedulable: true,
         ansible_host: '192.168.50.22',
-        ansible_ssh_private_key_file: "/home/vagrant/.ssh/node2.key"
+        ansible_ssh_private_key_file: "/home/vagrant/.ssh/node2.key",
+        openshift_node_group_name: "node-config-compute"
       },
       admin1: {
         ansible_connection: 'local',
         deployment_type: deployment_type
       }
     }
+
+    if deployment_type == 'openshift-enterprise'
+      pre_playbook = "/usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml"
+      cluster_playbook = "/usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml"
+    else
+      pre_playbook = "/home/vagrant/openshift-ansible/playbooks/prerequisites.yml"
+      cluster_playbook = "/home/vagrant/openshift-ansible/playbooks/deploy_cluster.yml"
+    end
 
     admin1.vm.provision :ansible_local do |ansible|
       ansible.verbose        = true
@@ -234,7 +232,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.install        = false
       ansible.limit          = "OSEv3:localhost"
       ansible.provisioning_path = '/home/vagrant/sync/vagrant'
-      ansible.playbook = config_playbook
+      ansible.playbook = pre_playbook
+      ansible.groups = ansible_groups
+      ansible.host_vars = ansible_host_vars
+    end
+
+    admin1.vm.provision :ansible_local do |ansible|
+      ansible.verbose        = true
+      ansible.install        = false
+      ansible.limit          = "OSEv3:localhost"
+      ansible.provisioning_path = '/home/vagrant/sync/vagrant'
+      ansible.playbook = cluster_playbook
       ansible.groups = ansible_groups
       ansible.host_vars = ansible_host_vars
     end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -103,7 +103,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v, override|
     #v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//vagrant","1"]
-    v.memory = 1024
+    v.memory = 2048
     v.cpus = 1
     override.vm.box = box_name
     provider_name = 'virtualbox'
@@ -111,7 +111,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "libvirt" do |libvirt, override|
     libvirt.cpus = 1
-    libvirt.memory = 1024
+    libvirt.memory = 2048
     libvirt.driver = 'kvm'
     override.vm.box = box_name
     provider_name = 'libvirt'
@@ -157,6 +157,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         openshift_deployment_type: deployment_type,
         openshift_clock_enabled: true,
         os_firewall_use_firewalld: true,
+        openshift_disable_check: "docker_storage,memory_availability,package_version",
         openshift_master_identity_providers: "[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'file': '/etc/origin/master/htpasswd'}]",
         openshift_master_htpasswd_users: "{'admin': '$apr1$nWG7vwhy$jCMCBmBrW3MEYmCFCckYk1'}",
         openshift_master_default_subdomain: 'apps.example.com',

--- a/vagrant/tasks/install_bootstrap_origin.yaml
+++ b/vagrant/tasks/install_bootstrap_origin.yaml
@@ -7,6 +7,7 @@
     dest: ~/openshift-ansible
     force: yes
     update: yes
+    version: release-3.10
   become: yes
   become_user: vagrant
 - package:


### PR DESCRIPTION
#### What does this PR do?
Adjusted Vagrantfile and provisioning playbook to work with OpenShift 3.10.

Changes to Vagrantfile
- Increased default VM memory
- Adjusted generated inventory to run with current installer version
- Changed provisioned playbooks because they changed the installer playbooks with OpenShift 3.9

Changes to provisioning playbook:
- Pinned openshift-ansible repository to branch "release-3.10"

#### How should this be manually tested?
```bash
vagrant plugin install vagrant-sshfs landrush vagrant-hostmanager
cd vagrant
vagrant up
```
See vagrant/README.md for more documentation.

#### Is there a relevant Issue open for this?
#931 

#### Who would you like to review this?
cc: @e-minguez 
