### PR TITLE
Removed Security Group Rule for TCP 2049

### DIFF
--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygrouprule.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/securitygrouprule.yaml
@@ -66,12 +66,6 @@
         },
         {
         'proto': 'tcp',
-        'from_port': '2049',
-        'to_port': '2049',
-        'group_name': 'node'
-        },
-        {
-        'proto': 'tcp',
         'from_port': '8053',
         'to_port': '8053',
         'group_name': 'node'


### PR DESCRIPTION

#### What does this PR do?
This removes the security group rule for port 2049.  This port is for NFS and is not needed in the current reference architecture.
