### PR TITLE
Add support to firewalld and iptables

### DIFF
--- a/reference-architecture/day2ops/scripts/backup_master_node.sh
+++ b/reference-architecture/day2ops/scripts/backup_master_node.sh
@@ -38,7 +38,7 @@ otherfiles(){
     cp -a /etc/sysconfig/flanneld \
       ${BACKUPLOCATION}/etc/sysconfig/
   fi
-  cp -aR /etc/sysconfig/{iptables,docker-*} \
+  cp -aR /etc/sysconfig/docker-* \
     ${BACKUPLOCATION}/etc/sysconfig/
   if [ -d /etc/cni ]
   then
@@ -47,6 +47,15 @@ otherfiles(){
   cp -aR /etc/dnsmasq* ${BACKUPLOCATION}/etc/
   cp -aR /etc/pki/ca-trust/source/anchors/* \
     ${BACKUPLOCATION}/etc/pki/ca-trust/source/anchors/
+}
+
+firewall_files(){
+  if $(firewall-cmd --state --quiet); then
+    cp -aR /etc/sysconfig/firewalld ${BACKUPLOCATION}/etc/sysconfig/
+    cp -aR /etc/firewalld ${BACKUPLOCATION}/etc/
+  else
+    cp -aR /etc/sysconfig/iptables ${BACKUPLOCATION}/etc/sysconfig/
+  fi
 }
 
 packagelist(){
@@ -66,6 +75,7 @@ mkdir -p ${BACKUPLOCATION}
 
 ocpfiles
 otherfiles
+firewall_files
 packagelist
 
 exit 0


### PR DESCRIPTION
Fixes #1059

According to https://bugzilla.redhat.com/show_bug.cgi?id=1181335 /etc/firewalld (and /etc/sysconfig/firewalld) should be backed up.

#### What does this PR do?
Backup firewalld or iptables

#### How should this be manually tested?
Run the script

#### Is there a relevant Issue open for this?
#1059 

#### Who would you like to review this?
cc: @cooktheryan  PTAL
