### PR TITLE
Fix JSON output of namespaces in project_export.sh

### DIFF
--- a/reference-architecture/day2ops/scripts/project_export.sh
+++ b/reference-architecture/day2ops/scripts/project_export.sh
@@ -52,7 +52,7 @@ exportlist(){
   fi
 
   # return if list empty
-  if [ $(echo ${BUFFER} | jq '.items | length > 0') == "false" ]; then
+  if [ "$(echo ${BUFFER} | jq '.items | length > 0')" == "false" ]; then
     echo "Skipped: list empty"
     return
   fi
@@ -61,16 +61,15 @@ exportlist(){
 }
 
 ns(){
-  exportlist \
-    ns \
-    ns \
-    'del('\
-'.items[].status,'\
-'.items[].metadata.uid,'\
-'.items[].metadata.selfLink,'\
-'.items[].metadata.resourceVersion,'\
-'.items[].metadata.creationTimestamp,'\
-'.items[].metadata.generation)'
+  echo "Exporting namespace to ${PROJECT}/ns.json"
+  oc get --export -o=json ns ${PROJECT} | jq '
+    del(.status,
+        .metadata.uid,
+        .metadata.selfLink,
+        .metadata.resourceVersion,
+        .metadata.creationTimestamp,
+        .metadata.generation
+        )' > ${PROJECT}/ns.json
 }
 
 rolebindings(){


### PR DESCRIPTION
#### What does this PR do?
When a user with access to multiple projects is used to perform the
backup, all projects are being written to the <project_dir>/ns.json
files and a subsequent restore fails, because project_import.sh can't
detect the correct namespace to restore to.

#### How should this be manually tested?
Before the change (multiple items in the JSON object):
```
project_export.sh example
jq '.items | length' example/ns.json
17
```
After the change (items is not part of the JSON object anymore
```
project_export.sh example
jq '.items | length' example/ns.json
0
cat example/ns.json
{
  "apiVersion": "v1",
  "kind": "Namespace",
  "metadata": {
    "name": "adfinis"
  },
  "spec": {
    "finalizers": [
      "openshift.io/origin",
      "kubernetes"
    ]
  }
}
```

#### Who would you like to review this?
cc: @tomassedovic PTAL
