### PR TITLE
use satellite tools version 6.3

### DIFF
--- a/roles/rhsm/tasks/main.yaml
+++ b/roles/rhsm/tasks/main.yaml
@@ -82,7 +82,7 @@
         - "{{ openshift_required_repos | difference(enabled_repos.stdout_lines) }}"
 
     - name: Enable satellite tools repo if required
-      command: "subscription-manager repos --enable=rhel-7-server-satellite-tools-6.2-rpms"
+      command: "subscription-manager repos --enable=rhel-7-server-satellite-tools-6.3-rpms"
       when: rhsm_activation_key is defined and rhsm_activation_key|trim != ''
 
   when: ansible_distribution == "RedHat"


### PR DESCRIPTION
#### What does this PR do?
It use satellite tools version 6.3 in rhsm role for vmware reference architecture.

#### How should this be manually tested?
I use this script to deploy my own openshift cluster.

#### Is there a relevant Issue open for this?
No 

#### Who would you like to review this?
cc: @tomassedovic PTAL

This is my first pull request for this repo. Feedbacks are welcome