### PR TITLE
wip(satellite): introduce variable enabling satellite-tools repository

### DIFF
--- a/roles/rhsm/defaults/main.yaml
+++ b/roles/rhsm/defaults/main.yaml
@@ -1,2 +1,3 @@
 ---
 openshift_required_repos: ['rhel-7-server-rpms', 'rhel-7-server-extras-rpms', 'rhel-7-server-ose-3.9-rpms', 'rhel-7-fast-datapath-rpms']
+openshift_satellite_tools_repo: rhel7-server-satellite-tools-6.4-rpms

--- a/roles/rhsm/tasks/main.yaml
+++ b/roles/rhsm/tasks/main.yaml
@@ -82,7 +82,7 @@
         - "{{ openshift_required_repos | difference(enabled_repos.stdout_lines) }}"
 
     - name: Enable satellite tools repo if required
-      command: "subscription-manager repos --enable=rhel-7-server-satellite-tools-6.2-rpms"
+      command: "subscription-manager repos --enable={{ openshift_satellite_tools_repo }}"
       when: rhsm_activation_key is defined and rhsm_activation_key|trim != ''
 
   when: ansible_distribution == "RedHat"


### PR DESCRIPTION
#### What does this PR do?

Updates @Vskilet contribution ( #1081 ), introducing a variable switching satellite-tools version, celebrating Satellite 6.4 release.

#### How should this be manually tested?

Having defined satellite-related configurations, such as `rhsm_activation_key`, `rhsm_org_id`, ... Apply prerequisites and deploy cluster:

```
ansible-playbook playbooks/prerequisite.yaml
ansible-playbook playbooks/deploy-host.yaml
```

#### Is there a relevant Issue open for this?

None

#### Who would you like to review this?

cc: @tomassedovic PTAL
