### PR TITLE
Correct handling of multiple image change triggers

### DIFF
--- a/reference-architecture/day2ops/scripts/project_export.sh
+++ b/reference-architecture/day2ops/scripts/project_export.sh
@@ -130,11 +130,13 @@ dcs(){
           .spec.triggers[].imageChangeParams.lastTriggeredImage
           )' > ${PROJECT}/dc_${dc}.json
     if [ !$(cat ${PROJECT}/dc_${dc}.json | jq '.spec.triggers[].type' | grep -q "ImageChange") ]; then
-      for container in $(cat ${PROJECT}/dc_${dc}.json | jq -r '.spec.triggers[] | select(.type == "ImageChange") .imageChangeParams.containerNames[]'); do
-        echo "Patching DC..."
-        OLD_IMAGE=$(cat ${PROJECT}/dc_${dc}.json | jq --arg cname ${container} -r '.spec.template.spec.containers[] | select(.name == $cname)| .image')
-        NEW_IMAGE=$(cat ${PROJECT}/dc_${dc}.json | jq -r '.spec.triggers[] | select(.type == "ImageChange") .imageChangeParams.from.name // empty')
-        sed -e "s#$OLD_IMAGE#$NEW_IMAGE#g" ${PROJECT}/dc_${dc}.json >> ${PROJECT}/dc_${dc}_patched.json
+      cp -f ${PROJECT}/dc_${dc}.json ${PROJECT}/dc_${dc}_patched.json
+
+      for container in $(cat ${PROJECT}/dc_${dc}_patched.json | jq -r '.spec.triggers[] | select(.type == "ImageChange") .imageChangeParams.containerNames[]'); do
+        OLD_IMAGE=$(cat ${PROJECT}/dc_${dc}_patched.json | jq --arg cname ${container} -r '.spec.template.spec.containers[] | select(.name == $cname)| .image')
+        NEW_IMAGE=$(cat ${PROJECT}/dc_${dc}_patched.json | jq --arg cname ${container} -r '.spec.triggers[] | select((.type == "ImageChange") and (.imageChangeParams.containerNames[] == $cname)) .imageChangeParams.from.name // empty')
+        echo "Patching DC ${dc} ... ${OLD_IMAGE} -> ${NEW_IMAGE}"
+        sed -i -e "s#$OLD_IMAGE#$NEW_IMAGE#g" ${PROJECT}/dc_${dc}_patched.json
       done
     fi
   done


### PR DESCRIPTION
#### What does this PR do?
This change corrects the handling of Deployment Configs with multiple image streams.

#### How should this be manually tested?
Create a Deployment config with two containers. Each Container should have its image change trigger:

```
    "triggers": [
      {
        "type": "ConfigChange"
      },
      {
        "imageChangeParams": {
          "automatic": true,
          "containerNames": [
            "nginx"
          ],
          "from": {
            "kind": "ImageStreamTag",
            "name": "nginx:latest"
          }
        },
        "type": "ImageChange"
      },
      {
        "imageChangeParams": {
          "automatic": true,
          "containerNames": [
            "php"
          ],
          "from": {
            "kind": "ImageStreamTag",
            "name": "php:latest",
            "namespace": "ns"
          }
        },
        "type": "ImageChange"
      }
    ]
  }

```
#### Is there a relevant Issue open for this?
-

#### Who would you like to review this?
cc: @tomassedovic PTAL
