### PR TITLE
fix EC2 loop

### DIFF
--- a/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2.yaml
+++ b/reference-architecture/3.9/playbooks/roles/aws/tasks/ec2.yaml
@@ -87,24 +87,12 @@
     vpc_subnet_id: "{{ item.subnet }}"
     wait: yes
   with_items: "\
-{%- set i = 1 -%}
-{%- set j = 0 -%}
 {%- for k in range(0, ( ec2_count_master if ec2_count_master is defined else 3 ) ) -%}
     {
-'name': 'master{{ i }}',
-'subnet': '{{ subnet_private.results[j].subnet.id if subnet_private is defined else '' }}',
+'name': 'master{{ k + 1 }}',
+'subnet': '{{ subnet_private.results[k % subnet_private.results | length].subnet.id if subnet_private is defined else '' }}',
 'type': '{{ ec2_type_master }}'
     },
-    {%- if i <= ( ec2_count_master if ec2_count_master is defined else 3 ) -%}
-        {%- set i = i + 1 -%}
-    {%- endif -%}
-    {%- if subnet_private is defined -%}
-      {%- if j < subnet_private.results | length - 1 -%}
-          {%- set j = j + 1 -%}
-      {%- else -%}
-          {%- set j = 0 -%}
-      {%- endif -%}
-    {%- endif -%}
 {%- endfor -%}
     "
   retries: 3
@@ -188,24 +176,12 @@
     vpc_subnet_id: "{{ item.subnet }}"
     wait: yes
   with_items: "\
-{%- set i = 1 -%}
-{%- set j = 0 -%}
 {%- for k in range(0, ( ec2_count_infra if ec2_count_infra is defined else 3 ) ) -%}
     {
-'name': 'infra{{ i }}',
-'subnet': '{{ subnet_private.results[j].subnet.id if (state is undefined or 'absent' not in state) else '' }}',
+'name': 'infra{{ k + 1 }}',
+'subnet': '{{ subnet_private.results[k % subnet_private.results | length].subnet.id if (state is undefined or 'absent' not in state) else '' }}',
 'type': '{{ ec2_type_infra }}'
     },
-    {%- if i <= ( ec2_count_infra if ec2_count_infra is defined else 3 ) -%}
-        {%- set i = i + 1 -%}
-    {%- endif -%}
-    {%- if subnet_private is defined -%}
-      {%- if j < subnet_private.results | length - 1 -%}
-          {%- set j = j + 1 -%}
-      {%- else -%}
-          {%- set j = 0 -%}
-      {%- endif -%}
-    {%- endif -%}
 {%- endfor -%}
     "
   retries: 3
@@ -280,24 +256,12 @@
     vpc_subnet_id: "{{ item.subnet }}"
     wait: yes
   with_items: "\
-{%- set i = 1 -%}
-{%- set j = 0 -%}
 {%- for k in range(0, ( ec2_count_node if ec2_count_node is defined else 3 ) ) -%}
     {
-'name': 'node{{ i }}',
-'subnet': '{{ subnet_private.results[j].subnet.id if subnet_private is defined else '' }}',
+'name': 'node{{ k + 1 }}',
+'subnet': '{{ subnet_private.results[k % subnet_private.results | length].subnet.id if subnet_private is defined else '' }}',
 'type': '{{ ec2_type_node }}'
     },
-    {%- if i <= ( ec2_count_node if ec2_count_node is defined else 3 ) -%}
-        {%- set i = i + 1 -%}
-    {%- endif -%}
-    {%- if subnet_private is defined -%}
-      {%- if j < subnet_private.results | length - 1 -%}
-          {%- set j = j + 1 -%}
-      {%- else -%}
-          {%- set j = 0 -%}
-      {%- endif -%}
-    {%- endif -%}
 {%- endfor -%}
     "
   retries: 3


### PR DESCRIPTION
#### What does this PR do?
The Jinja2 loop that creates the EC2 instances didn't work with Ansible 2.7.4 and Python 2.7.15 on Fedora 28 and 29.

With 3 private subnets, the ec2 task was executed three times, but with the same EC2 instance name and the same subnet ID each time. It looked like the variables i and j stayed at 1 and 0 for each loop iteration.

On RHEL 7 with Ansible 2.7.4 and Python 2.7.5, this did not happen. The new code works on both Fedora 28/29 and RHEL 7.6.

#### How should this be manually tested?
This can be verified by following the instructions in https://access.redhat.com/documentation/en-us/reference_architectures/2018/html-single/deploying_and_managing_openshift_3.9_on_amazon_web_services/

#### Is there a relevant Issue open for this?
no

#### Who would you like to review this?
cc: @tomassedovic PTAL
