### PR TITLE
fixes #1091 by surrounding BUFFER variable with double quotes

### DIFF
--- a/reference-architecture/day2ops/scripts/project_export.sh
+++ b/reference-architecture/day2ops/scripts/project_export.sh
@@ -52,12 +52,12 @@ exportlist(){
   fi
 
   # return if list empty
-  if [ "$(echo ${BUFFER} | jq '.items | length > 0')" == "false" ]; then
+  if [ "$(echo \"${BUFFER}\" | jq '.items | length > 0')" == "false" ]; then
     echo "Skipped: list empty"
     return
   fi
 
-  echo ${BUFFER} | jq ${DELETEPARAM} > ${PROJECT}/${BASENAME}.json
+  echo "${BUFFER}" | jq ${DELETEPARAM} > ${PROJECT}/${BASENAME}.json
 }
 
 ns(){


### PR DESCRIPTION
#### What does this PR do?
surround BUFFER variable with double quotes to avoid asterisk interpretion of shell interpreter

#### How should this be manually tested?
./project_export.sh <project>
check created cronjob.json file for correct scheduling entries

#### Is there a relevant Issue open for this?
https://github.com/openshift/openshift-ansible-contrib/issues/1091

#### Who would you like to review this?
cc: @tomassedovic PTAL
