### PR TITLE
Fix trust anchors backup when file does not exist

### DIFF
--- a/reference-architecture/day2ops/scripts/backup_master_node.sh
+++ b/reference-architecture/day2ops/scripts/backup_master_node.sh
@@ -31,7 +31,7 @@ ocpfiles(){
 
 otherfiles(){
   mkdir -p ${BACKUPLOCATION}/etc/sysconfig
-  mkdir -p ${BACKUPLOCATION}/etc/pki/ca-trust/source/anchors
+  mkdir -p ${BACKUPLOCATION}/etc/pki/ca-trust/source
   echo "Exporting other important files to ${BACKUPLOCATION}"
   if [ -f /etc/sysconfig/flanneld ]
   then
@@ -45,8 +45,8 @@ otherfiles(){
     cp -aR /etc/cni ${BACKUPLOCATION}/etc/
   fi
   cp -aR /etc/dnsmasq* ${BACKUPLOCATION}/etc/
-  cp -aR /etc/pki/ca-trust/source/anchors/* \
-    ${BACKUPLOCATION}/etc/pki/ca-trust/source/anchors/
+  cp -aR /etc/pki/ca-trust/source/anchors \
+    ${BACKUPLOCATION}/etc/pki/ca-trust/source/
 }
 
 packagelist(){


### PR DESCRIPTION
#### What does this PR do?
Backs up trust anchors directory because backup_master_node.sh fails when trust anchors file does not exist.

#### How should this be manually tested?

Run the following commands on OpenShift node 
```
mkdir -p /tmp/test
curl -O https://raw.githubusercontent.com/eramoto/openshift-ansible-contrib/backup-trust-anchors/reference-architecture/day2ops/scripts/backup_master_node.sh
bash -xe backup_master_node.sh /tmp/test
```
if success, anchros directory exist
```
ls /tmp/test/etc/pki/ca-trust/source/
```

#### Is there a relevant Issue open for this?
None.

#### Who would you like to review this?
cc: @tomassedovic PTAL
