### PR TITLE
Fixed the number or created repositories (#1098)

### DIFF
--- a/reference-architecture/day2ops/scripts/ocp36-sat6.py
+++ b/reference-architecture/day2ops/scripts/ocp36-sat6.py
@@ -17,7 +17,7 @@ class ocpSat6(object):
             self._syncData()
 
     def _loadImageList(self):
-        cmd='curl -s https://registry.access.redhat.com/v1/search?q="openshift3" | python -mjson.tool | grep ".name.:" | cut -d: -f2 | sed -e "s/ "//g"" -e "s/,"//g""'
+        cmd='curl -s https://registry.access.redhat.com/v1/search?q="openshift3" | python -mjson.tool | grep ".name.:" | cut -d: -f2 | sed -e "s/ "//g"" -e "s/,"//g"" | grep -E \'(ose-haproxy-router|registry-console|ose-deployer|ose-pod|ose-docker-registry)\''
         result = subprocess.check_output(cmd, shell=True)
         lines = result.splitlines()
         for line in lines:


### PR DESCRIPTION
Hello

The code was fixed and now it's according the expected.
```
[root@wallsat65 script1]# ./ocp36-sat6.py --password redhat
Adding OCP images to org ID: 1 with the product name: ocp36
Continue? y/n:
y
Adding product with name: ocp36
Product created.
Adding openshift3 images
Repository created.
Repository created.
Repository created.
Repository created.
Repository created.
The following vars should exist in your OpenShift install playbook
oreg_url: defaultorganization-ocp36-openshift3_ose-${component}:${version}
openshift_disable_check: "docker_image_availability"
openshift_docker_insecure_registries: "wallsat65.usersys.redhat.com:5000"
openshift_docker_additional_registries: "wallsat65.usersys.redhat.com:5000"
openshift_examples_modify_imagestreams: True
Sync repo data? (This may take a while)
Continue? y/n:
y
...
```

Only 5 repos created according the manual steps (in order to skip the script).

Please check and merge ASAP the code, we have a lot of consultants using this script and causing problems on Satellite (disk reaching 100%).

Thank you.