### PR TITLE
Check jq as required command in project_import.sh

### DIFF
--- a/reference-architecture/day2ops/scripts/project_import.sh
+++ b/reference-architecture/day2ops/scripts/project_import.sh
@@ -37,7 +37,7 @@ then
   die "Missing project directory" 3
 fi
 
-for i in oc
+for i in jq oc
 do
   command -v $i >/dev/null 2>&1 || die "$i required but not found" 3
 done


### PR DESCRIPTION
#### What does this PR do?

Check jq as required command even if project_export.sh is run on a machine and project_import.sh is run on another machine.


#### How should this be manually tested?

If jq command exists, the shell script outputs `Are you sure?` (You enter `n` when you want to cancel it)
```
$ which oc
/usr/bin/oc
$ which jq
/usr/bin/jq
$ reference-architecture/day2ops/scripts/project_import.sh foobar
...
Are you sure? n
User cancel
```

If jq command does not exist, the shell script outputs `jq required but not found`
```
$ which oc
/usr/bin/oc
$ which jq 
/usr/bin/which: no jq in (/usr/share/Modules/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin)
$ reference-architecture/day2ops/scripts/project_import.sh foobar
jq required but not found
```


#### Is there a relevant Issue open for this?

None.


#### Who would you like to review this?
cc: @tomassedovic PTAL