### PR TITLE
updated molecule dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,5 @@ flake8-mutable
 flake8-print==3.0.1
 PyYAML
 yamllint
-git+https://github.com/metacloud/molecule@master
+molecule[lint]
 docker-py==1.10.6


### PR DESCRIPTION
#### What does this PR do?
Updated the test dependency on molecule to use Pypi instead of a direct dependency to avoid [Repo Jacking](https://blog.securityinnovation.com/repo-jacking-exploiting-the-dependency-supply-chain#analysis)

#### How should this be manually tested?
Run the molecule tests:
`tox -r -e py35-ansible22-molecule`

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @tomassedovic PTAL
